### PR TITLE
Can you consider removing material and cupertino?

### DIFF
--- a/example/lib/pages/table.dart
+++ b/example/lib/pages/table.dart
@@ -118,7 +118,6 @@ class TablePage extends StatelessWidget {
   }
 }
 
-
 /* With builder it will be
 const invoices = [
   [

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -1,7 +1,8 @@
 // ignore_for_file: lines_longer_than_80_chars
 
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
+import 'dart:ui';
+
+import 'package:flutter/widgets.dart';
 import 'package:flutter_localizations/flutter_localizations.dart'
     show
         GlobalCupertinoLocalizations,

--- a/lib/src/components/accordion.dart
+++ b/lib/src/components/accordion.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:shadcn_ui/src/components/image.dart';

--- a/lib/src/components/alert.dart
+++ b/lib/src/components/alert.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/src/components/image.dart';
 import 'package:shadcn_ui/src/theme/components/decorator.dart';
 import 'package:shadcn_ui/src/theme/theme.dart';

--- a/lib/src/components/avatar.dart
+++ b/lib/src/components/avatar.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';
 import 'package:shadcn_ui/src/utils/debug_check.dart';
 

--- a/lib/src/components/button.dart
+++ b/lib/src/components/button.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter/services.dart';
 import 'package:shadcn_ui/src/raw_components/focusable.dart';
 import 'package:shadcn_ui/src/theme/components/button.dart';

--- a/lib/src/components/checkbox.dart
+++ b/lib/src/components/checkbox.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:shadcn_ui/src/components/disabled.dart';

--- a/lib/src/components/dialog.dart
+++ b/lib/src/components/dialog.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:shadcn_ui/src/components/button.dart';

--- a/lib/src/components/form/fields/checkbox.dart
+++ b/lib/src/components/form/fields/checkbox.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/src/components/checkbox.dart';
 import 'package:shadcn_ui/src/components/form/field.dart';
 import 'package:shadcn_ui/src/theme/components/decorator.dart';

--- a/lib/src/components/form/fields/input.dart
+++ b/lib/src/components/form/fields/input.dart
@@ -1,7 +1,7 @@
 import 'dart:ui' as ui;
 
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter/services.dart';
 import 'package:shadcn_ui/src/components/form/field.dart';
 import 'package:shadcn_ui/src/components/input.dart';

--- a/lib/src/components/form/fields/radio.dart
+++ b/lib/src/components/form/fields/radio.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/src/components/form/field.dart';
 import 'package:shadcn_ui/src/components/radio.dart';
 

--- a/lib/src/components/form/fields/select.dart
+++ b/lib/src/components/form/fields/select.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/src/components/form/field.dart';
 import 'package:shadcn_ui/src/components/select.dart';
 import 'package:shadcn_ui/src/raw_components/portal.dart';

--- a/lib/src/components/form/fields/switch.dart
+++ b/lib/src/components/form/fields/switch.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/src/components/form/field.dart';
 import 'package:shadcn_ui/src/components/switch.dart';
 import 'package:shadcn_ui/src/theme/components/decorator.dart';

--- a/lib/src/components/form/form.dart
+++ b/lib/src/components/form/form.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/src/components/form/field.dart';
 
 typedef ShadFormFields = Map<Object,

--- a/lib/src/components/image.dart
+++ b/lib/src/components/image.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:vector_graphics/vector_graphics.dart';
 

--- a/lib/src/components/input.dart
+++ b/lib/src/components/input.dart
@@ -1,8 +1,8 @@
 import 'dart:ui' as ui;
 
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/src/components/disabled.dart';
 import 'package:shadcn_ui/src/theme/components/decorator.dart';
 import 'package:shadcn_ui/src/theme/theme.dart';

--- a/lib/src/components/popover.dart
+++ b/lib/src/components/popover.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:shadcn_ui/src/raw_components/portal.dart';
 import 'package:shadcn_ui/src/theme/components/decorator.dart';

--- a/lib/src/components/progress.dart
+++ b/lib/src/components/progress.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/src/theme/theme.dart';
 
 class ShadProgress extends StatelessWidget {

--- a/lib/src/components/radio.dart
+++ b/lib/src/components/radio.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_animate/flutter_animate.dart';

--- a/lib/src/components/resizable.dart
+++ b/lib/src/components/resizable.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:shadcn_ui/src/components/image.dart';
 import 'package:shadcn_ui/src/theme/components/decorator.dart';

--- a/lib/src/components/select.dart
+++ b/lib/src/components/select.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:shadcn_ui/src/components/disabled.dart';
 import 'package:shadcn_ui/src/components/image.dart';

--- a/lib/src/components/sheet.dart
+++ b/lib/src/components/sheet.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:shadcn_ui/src/components/dialog.dart';
 import 'package:shadcn_ui/src/components/image.dart';

--- a/lib/src/components/slider.dart
+++ b/lib/src/components/slider.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 
 import 'package:shadcn_ui/src/theme/theme.dart';
 

--- a/lib/src/components/switch.dart
+++ b/lib/src/components/switch.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:shadcn_ui/src/components/disabled.dart';
 import 'package:shadcn_ui/src/raw_components/focusable.dart';

--- a/lib/src/components/table.dart
+++ b/lib/src/components/table.dart
@@ -1,6 +1,4 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/src/theme/theme.dart';
 import 'package:two_dimensional_scrollables/two_dimensional_scrollables.dart';

--- a/lib/src/components/toast.dart
+++ b/lib/src/components/toast.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 

--- a/lib/src/components/tooltip.dart
+++ b/lib/src/components/tooltip.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:shadcn_ui/src/components/popover.dart';
 import 'package:shadcn_ui/src/raw_components/portal.dart';

--- a/lib/src/raw_components/portal.dart
+++ b/lib/src/raw_components/portal.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 
 /// The position of the [ShadPortal] in the global coordinate system.
 sealed class ShadAnchorBase {

--- a/lib/src/theme/color_scheme/blue.dart
+++ b/lib/src/theme/color_scheme/blue.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/src/theme/color_scheme/base.dart';
 

--- a/lib/src/theme/color_scheme/gray.dart
+++ b/lib/src/theme/color_scheme/gray.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/src/theme/color_scheme/base.dart';
 

--- a/lib/src/theme/color_scheme/green.dart
+++ b/lib/src/theme/color_scheme/green.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/src/theme/color_scheme/base.dart';
 

--- a/lib/src/theme/color_scheme/neutral.dart
+++ b/lib/src/theme/color_scheme/neutral.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/src/theme/color_scheme/base.dart';
 

--- a/lib/src/theme/color_scheme/orange.dart
+++ b/lib/src/theme/color_scheme/orange.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/src/theme/color_scheme/base.dart';
 

--- a/lib/src/theme/color_scheme/red.dart
+++ b/lib/src/theme/color_scheme/red.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/src/theme/color_scheme/base.dart';
 

--- a/lib/src/theme/color_scheme/rose.dart
+++ b/lib/src/theme/color_scheme/rose.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/src/theme/color_scheme/base.dart';
 

--- a/lib/src/theme/color_scheme/slate.dart
+++ b/lib/src/theme/color_scheme/slate.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/src/theme/color_scheme/base.dart';
 

--- a/lib/src/theme/color_scheme/stone.dart
+++ b/lib/src/theme/color_scheme/stone.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/src/theme/color_scheme/base.dart';
 

--- a/lib/src/theme/color_scheme/violet.dart
+++ b/lib/src/theme/color_scheme/violet.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/src/theme/color_scheme/base.dart';
 

--- a/lib/src/theme/color_scheme/yellow.dart
+++ b/lib/src/theme/color_scheme/yellow.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/src/theme/color_scheme/base.dart';
 

--- a/lib/src/theme/color_scheme/zinc.dart
+++ b/lib/src/theme/color_scheme/zinc.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/src/theme/color_scheme/base.dart';
 

--- a/lib/src/theme/components/button.dart
+++ b/lib/src/theme/components/button.dart
@@ -1,7 +1,7 @@
 import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/src/components/button.dart';
 import 'package:shadcn_ui/src/theme/components/decorator.dart';

--- a/lib/src/theme/components/decorator.dart
+++ b/lib/src/theme/components/decorator.dart
@@ -1,6 +1,6 @@
 import 'dart:ui';
 
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 
 import 'package:shadcn_ui/shadcn_ui.dart';
 import 'package:shadcn_ui/src/theme/theme.dart';

--- a/lib/src/theme/data.dart
+++ b/lib/src/theme/data.dart
@@ -1,6 +1,6 @@
 import 'dart:ui';
 
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/src/theme/color_scheme/base.dart';
 import 'package:shadcn_ui/src/theme/components/accordion.dart';
 import 'package:shadcn_ui/src/theme/components/alert.dart';

--- a/lib/src/theme/text_theme/theme.dart
+++ b/lib/src/theme/text_theme/theme.dart
@@ -1,5 +1,5 @@
 import 'dart:ui' as ui;
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/src/theme/text_theme/text_styles_default.dart';
 import 'package:shadcn_ui/src/theme/themes/component_defaults.dart';
 

--- a/lib/src/theme/themes/base.dart
+++ b/lib/src/theme/themes/base.dart
@@ -1,4 +1,6 @@
-import 'package:flutter/material.dart';
+import 'dart:ui';
+
+import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/src/theme/color_scheme/base.dart';
 import 'package:shadcn_ui/src/theme/components/accordion.dart';
 import 'package:shadcn_ui/src/theme/components/alert.dart';

--- a/lib/src/theme/themes/component_defaults.dart
+++ b/lib/src/theme/themes/component_defaults.dart
@@ -1,6 +1,5 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:lucide_icons_flutter/lucide_icons.dart';
 import 'package:shadcn_ui/src/raw_components/portal.dart';

--- a/lib/src/theme/themes/shadows.dart
+++ b/lib/src/theme/themes/shadows.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
 abstract class ShadShadows {

--- a/lib/src/utils/effects.dart
+++ b/lib/src/utils/effects.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 

--- a/lib/src/utils/gesture_detector.dart
+++ b/lib/src/utils/gesture_detector.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/src/theme/theme.dart';
 
 @immutable

--- a/lib/src/utils/mouse_cursor_provider.dart
+++ b/lib/src/utils/mouse_cursor_provider.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 
 import 'package:shadcn_ui/shadcn_ui.dart';
 

--- a/lib/src/utils/provider.dart
+++ b/lib/src/utils/provider.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/widgets.dart';
 
 extension ProviderReadExt on BuildContext {
   T read<T>() => ShadProvider.of<T>(this, listen: false);

--- a/lib/src/utils/responsive.dart
+++ b/lib/src/utils/responsive.dart
@@ -1,6 +1,6 @@
 import 'dart:ui';
 
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/src/theme/theme.dart';
 
 class ShadBreakpoints {


### PR DESCRIPTION
Like shadcn only depends on radix. This library should only depend on widgets.
I tried but a lot of work need to be done here.
Like missing Separator (Divider in material), Progress (LinearProgressIndicator in material)