### PR TITLE
fix: ShadInput keyboard appearance has light mode only

### DIFF
--- a/lib/src/components/input.dart
+++ b/lib/src/components/input.dart
@@ -376,6 +376,9 @@ class ShadInputState extends State<ShadInput>
                                                 theme.colorScheme.selection
                                             : null,
                                         keyboardType: widget.keyboardType,
+                                        keyboardAppearance:
+                                            widget.keyboardAppearance ??
+                                                theme.brightness,
                                         textInputAction: widget.textInputAction,
                                         textCapitalization:
                                             widget.textCapitalization,


### PR DESCRIPTION
This pull request addresses the issue where the `keyboardAppearance` property was not being passed to the `EditableText` widget, resulting in an incorrect keyboard appearance.