### PR TITLE
feat: add materialTextTheme to `ShadThemeData`

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -637,7 +637,7 @@ class _ShadAppState extends State<ShadApp> {
     );
     mTheme = mTheme.copyWith(
       textTheme:
-          themeData.textTheme.materialTextTheme(textTheme: mTheme.textTheme),
+          themeData.materialTextTheme ?? themeData.textTheme.materialTextTheme(textTheme: mTheme.textTheme),
     );
 
     if (widget.materialThemeBuilder == null) {

--- a/lib/src/theme/data.dart
+++ b/lib/src/theme/data.dart
@@ -80,6 +80,7 @@ class ShadThemeData extends ShadBaseTheme {
     bool? disableSecondaryBorder,
     ShadTabsTheme? tabsTheme,
     ShadThemeVariant? variant,
+    TextTheme? materialTextTheme,
   }) {
     final effectiveRadius =
         radius ?? const BorderRadius.all(Radius.circular(6));
@@ -214,6 +215,7 @@ class ShadThemeData extends ShadBaseTheme {
       hoverStrategies: hoverStrategies ?? effectiveVariant.hoverStrategies(),
       disableSecondaryBorder: effectiveDisableSecondaryBorder,
       tabsTheme: effectiveVariant.tabsTheme().mergeWith(tabsTheme),
+      materilTextTheme: materialTextTheme,
     );
   }
 
@@ -262,6 +264,7 @@ class ShadThemeData extends ShadBaseTheme {
     required super.hoverStrategies,
     required super.disableSecondaryBorder,
     required super.tabsTheme,
+    required super.materialTextTheme,
   });
 
   static ShadThemeData lerp(ShadThemeData a, ShadThemeData b, double t) {

--- a/lib/src/theme/themes/base.dart
+++ b/lib/src/theme/themes/base.dart
@@ -120,6 +120,7 @@ abstract class ShadBaseTheme {
   final ShadHoverStrategies hoverStrategies;
   final bool disableSecondaryBorder;
   final ShadTabsTheme tabsTheme;
+  final TextTheme? materialTextTheme;
 }
 
 @immutable


### PR DESCRIPTION
Now you can override material text theme by passing materialTextTheme in the `ShadThemeData`.