### PR TITLE
chore: remove unnecessary track color in switch

### DIFF
--- a/lib/src/components/form/fields/switch.dart
+++ b/lib/src/components/form/fields/switch.dart
@@ -23,7 +23,6 @@ class ShadSwitchFormField extends ShadFormBuilderField<bool> {
     super.focusNode,
     String? Function(bool)? validator,
     Color? thumbColor,
-    Color? trackColor,
     Color? uncheckedTrackColor,
     Color? checkedTrackColor,
     double? width,

--- a/lib/src/components/form/fields/switch.dart
+++ b/lib/src/components/form/fields/switch.dart
@@ -64,7 +64,6 @@ class ShadSwitchFormField extends ShadFormBuilderField<bool> {
               width: width,
               margin: margin,
               thumbColor: thumbColor,
-              trackColor: trackColor,
               uncheckedTrackColor: uncheckedTrackColor,
               checkedTrackColor: checkedTrackColor,
             );

--- a/lib/src/components/switch.dart
+++ b/lib/src/components/switch.dart
@@ -15,7 +15,6 @@ class ShadSwitch extends StatefulWidget {
     this.onChanged,
     this.focusNode,
     this.thumbColor,
-    this.trackColor,
     this.uncheckedTrackColor,
     this.checkedTrackColor,
     this.width,
@@ -43,9 +42,6 @@ class ShadSwitch extends StatefulWidget {
 
   /// The color of the switch thumb.
   final Color? thumbColor;
-
-  /// The color of the switch track.
-  final Color? trackColor;
 
   /// The color of the unchecked track.
   final Color? uncheckedTrackColor;

--- a/lib/src/theme/components/switch.dart
+++ b/lib/src/theme/components/switch.dart
@@ -8,7 +8,6 @@ class ShadSwitchTheme {
   const ShadSwitchTheme({
     this.merge = true,
     this.thumbColor,
-    this.trackColor,
     this.uncheckedTrackColor,
     this.checkedTrackColor,
     this.width,
@@ -22,8 +21,6 @@ class ShadSwitchTheme {
   final bool merge;
 
   final Color? thumbColor;
-
-  final Color? trackColor;
 
   final Color? uncheckedTrackColor;
 
@@ -50,7 +47,6 @@ class ShadSwitchTheme {
     return ShadSwitchTheme(
       merge: b.merge,
       thumbColor: Color.lerp(a.thumbColor, b.thumbColor, t),
-      trackColor: Color.lerp(a.trackColor, b.trackColor, t),
       uncheckedTrackColor:
           Color.lerp(a.uncheckedTrackColor, b.uncheckedTrackColor, t),
       checkedTrackColor:
@@ -67,7 +63,6 @@ class ShadSwitchTheme {
   ShadSwitchTheme copyWith({
     bool? merge,
     Color? thumbColor,
-    Color? trackColor,
     Color? uncheckedTrackColor,
     Color? checkedTrackColor,
     double? width,
@@ -80,7 +75,6 @@ class ShadSwitchTheme {
     return ShadSwitchTheme(
       merge: merge ?? this.merge,
       thumbColor: thumbColor ?? this.thumbColor,
-      trackColor: trackColor ?? this.trackColor,
       uncheckedTrackColor: uncheckedTrackColor ?? this.uncheckedTrackColor,
       checkedTrackColor: checkedTrackColor ?? this.checkedTrackColor,
       width: width ?? this.width,
@@ -97,7 +91,6 @@ class ShadSwitchTheme {
     if (!other.merge) return other;
     return copyWith(
       thumbColor: other.thumbColor,
-      trackColor: other.trackColor,
       uncheckedTrackColor: other.uncheckedTrackColor,
       checkedTrackColor: other.checkedTrackColor,
       width: other.width,
@@ -116,7 +109,6 @@ class ShadSwitchTheme {
     return other is ShadSwitchTheme &&
         other.merge == merge &&
         other.thumbColor == thumbColor &&
-        other.trackColor == trackColor &&
         other.uncheckedTrackColor == uncheckedTrackColor &&
         other.checkedTrackColor == checkedTrackColor &&
         other.width == width &&
@@ -131,7 +123,6 @@ class ShadSwitchTheme {
   int get hashCode {
     return merge.hashCode ^
         thumbColor.hashCode ^
-        trackColor.hashCode ^
         uncheckedTrackColor.hashCode ^
         checkedTrackColor.hashCode ^
         width.hashCode ^


### PR DESCRIPTION
Removed the unused `trackColor` property from `ShadSwitch`. This property was not referenced anywhere in the code, and its presence was potentially confusing with the existing `uncheckedTrackColor` property.