### PR TITLE
Feat/order policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.17.5
 
 - **FEAT**: New `OrderPolicy`, `LinearOrderPolicy`, `ReverseOrderPolicy` and `CustomOrderPolicy` to update the order policy of the items in a list, this can be very useful to arrange the order of the parts of the shadcn components.
--**FEAT**: Add `orderPolicy` to `ShadOption`, `ShadAlert`, `ShadButton`, `ShadCheckbox`, `ShadCheckboxFormField`, `ShadDatePicker`, `ShadDatePickerFormField`, `ShadDateRangePickerFormField`, `ShadRadio`, `ShadSwitch`, `ShadSwitchFormField`, `ShadToast`.
+- **FEAT**: Add `orderPolicy` to `ShadOption`, `ShadAlert`, `ShadButton`, `ShadCheckbox`, `ShadCheckboxFormField`, `ShadDatePicker`, `ShadDatePickerFormField`, `ShadDateRangePickerFormField`, `ShadRadio`, `ShadSwitch`, `ShadSwitchFormField`, `ShadToast`.
 - **FEAT**: Add `expands` to `ShadButton`, defaults to false. Use it if you want the button's child to expand to fill the available space.
 
 ## 0.17.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.17.5
 
-- **FEAT**: New `OrderPolicy`, `LinearOrderPolicy`, `ReverseOrderPolicy` and `CustomOrderPolicy` to update the order policy of the items in a list.
--**FEAT**: Add `orderPolicy` to `ShadOption`.
+- **FEAT**: New `OrderPolicy`, `LinearOrderPolicy`, `ReverseOrderPolicy` and `CustomOrderPolicy` to update the order policy of the items in a list, this can be very useful to arrange the order of the parts of the shadcn components.
+-**FEAT**: Add `orderPolicy` to `ShadOption`, `ShadAlert`, `ShadButton`, `ShadCheckbox`, `ShadCheckboxFormField`, `ShadDatePicker`, `ShadDatePickerFormField`, `ShadDateRangePickerFormField`, `ShadRadio`, `ShadSwitch`, `ShadSwitchFormField`, `ShadToast`.
 
 ## 0.17.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.17.5
 
--**FEAT**: Add `placeSelectedIconFirst` to `ShadOption`, defaults to `true`.
+- **FEAT**: New `OrderPolicy`, `LinearOrderPolicy`, `ReverseOrderPolicy` and `CustomOrderPolicy` to update the order policy of the items in a list.
+-**FEAT**: Add `orderPolicy` to `ShadOption`.
 
 ## 0.17.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - **FEAT**: New `OrderPolicy`, `LinearOrderPolicy`, `ReverseOrderPolicy` and `CustomOrderPolicy` to update the order policy of the items in a list, this can be very useful to arrange the order of the parts of the shadcn components.
 -**FEAT**: Add `orderPolicy` to `ShadOption`, `ShadAlert`, `ShadButton`, `ShadCheckbox`, `ShadCheckboxFormField`, `ShadDatePicker`, `ShadDatePickerFormField`, `ShadDateRangePickerFormField`, `ShadRadio`, `ShadSwitch`, `ShadSwitchFormField`, `ShadToast`.
+- **FEAT**: Add `expands` to `ShadButton`, defaults to false. Use it if you want the button's child to expand to fill the available space.
 
 ## 0.17.4
 

--- a/example/lib/pages/radio_group.dart
+++ b/example/lib/pages/radio_group.dart
@@ -65,7 +65,6 @@ class _RadioPageState extends State<RadioPage> {
             (e) => ShadRadio(
               value: e,
               label: Text(e.message),
-              orderPolicy: WidgetOrderPolicy.reverse(),
             ),
           ),
         ),

--- a/example/lib/pages/radio_group.dart
+++ b/example/lib/pages/radio_group.dart
@@ -65,6 +65,7 @@ class _RadioPageState extends State<RadioPage> {
             (e) => ShadRadio(
               value: e,
               label: Text(e.message),
+              orderPolicy: WidgetOrderPolicy.reverse(),
             ),
           ),
         ),

--- a/example/lib/pages/switch.dart
+++ b/example/lib/pages/switch.dart
@@ -1,5 +1,6 @@
 import 'package:example/common/base_scaffold.dart';
 import 'package:example/common/properties/bool_property.dart';
+import 'package:example/common/properties/enum_property.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';

--- a/example/lib/pages/switch.dart
+++ b/example/lib/pages/switch.dart
@@ -1,6 +1,5 @@
 import 'package:example/common/base_scaffold.dart';
 import 'package:example/common/properties/bool_property.dart';
-import 'package:example/common/properties/enum_property.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/shadcn_ui.dart';

--- a/lib/shadcn_ui.dart
+++ b/lib/shadcn_ui.dart
@@ -104,6 +104,7 @@ export 'src/utils/effects.dart';
 export 'src/utils/extensions/breakpoints.dart';
 export 'src/utils/extensions/date_time.dart';
 export 'src/utils/extensions/duration.dart';
+export 'src/utils/extensions/order_policy.dart';
 export 'src/utils/gesture_detector.dart';
 export 'src/utils/mouse_area.dart';
 export 'src/utils/position.dart';

--- a/lib/src/components/alert.dart
+++ b/lib/src/components/alert.dart
@@ -3,6 +3,7 @@ import 'package:shadcn_ui/src/components/image.dart';
 import 'package:shadcn_ui/src/theme/components/decorator.dart';
 import 'package:shadcn_ui/src/theme/theme.dart';
 import 'package:shadcn_ui/src/utils/border.dart';
+import 'package:shadcn_ui/src/utils/extensions/order_policy.dart';
 
 enum ShadAlertVariant {
   primary,
@@ -25,6 +26,7 @@ class ShadAlert extends StatelessWidget {
     this.descriptionStyle,
     this.mainAxisAlignment,
     this.crossAxisAlignment,
+    this.orderPolicy,
   }) : variant = ShadAlertVariant.primary;
 
   const ShadAlert.destructive({
@@ -42,6 +44,7 @@ class ShadAlert extends StatelessWidget {
     this.descriptionStyle,
     this.mainAxisAlignment,
     this.crossAxisAlignment,
+    this.orderPolicy,
   }) : variant = ShadAlertVariant.destructive;
 
   const ShadAlert.raw({
@@ -60,6 +63,7 @@ class ShadAlert extends StatelessWidget {
     this.descriptionStyle,
     this.mainAxisAlignment,
     this.crossAxisAlignment,
+    this.orderPolicy,
   });
 
   final ShadAlertVariant variant;
@@ -76,6 +80,12 @@ class ShadAlert extends StatelessWidget {
   final TextStyle? descriptionStyle;
   final MainAxisAlignment? mainAxisAlignment;
   final CrossAxisAlignment? crossAxisAlignment;
+
+  /// {@template ShadAlert.orderPolicy}
+  /// The order policy of the items that compose the alert, defaults to
+  /// [WidgetOrderPolicy.linear()].
+  /// {@endtemplate}
+  final WidgetOrderPolicy? orderPolicy;
 
   @override
   Widget build(BuildContext context) {
@@ -142,6 +152,10 @@ class ShadAlert extends StatelessWidget {
         effectiveAlertTheme.crossAxisAlignment ??
         CrossAxisAlignment.start;
 
+    final effectiveOrderPolicy = orderPolicy ??
+        effectiveAlertTheme.orderPolicy ??
+        const WidgetOrderPolicy.linear();
+
     return ShadDecorator(
       decoration: effectiveDecoration,
       child: Row(
@@ -150,7 +164,7 @@ class ShadAlert extends StatelessWidget {
         textDirection: textDirection,
         children: [
           if (effectiveIcon != null) effectiveIcon,
-          Flexible(
+          Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               mainAxisSize: MainAxisSize.min,
@@ -168,7 +182,7 @@ class ShadAlert extends StatelessWidget {
               ],
             ),
           ),
-        ],
+        ].order(effectiveOrderPolicy),
       ),
     );
   }

--- a/lib/src/components/checkbox.dart
+++ b/lib/src/components/checkbox.dart
@@ -8,6 +8,7 @@ import 'package:shadcn_ui/src/raw_components/focusable.dart';
 import 'package:shadcn_ui/src/theme/components/decorator.dart';
 import 'package:shadcn_ui/src/theme/theme.dart';
 import 'package:shadcn_ui/src/utils/debug_check.dart';
+import 'package:shadcn_ui/src/utils/extensions/order_policy.dart';
 
 class ShadCheckbox extends StatefulWidget {
   const ShadCheckbox({
@@ -26,6 +27,7 @@ class ShadCheckbox extends StatefulWidget {
     this.padding,
     this.direction,
     this.crossAxisAlignment,
+    this.orderPolicy,
   });
 
   /// Whether the checkbox is on or off.
@@ -75,6 +77,12 @@ class ShadCheckbox extends StatefulWidget {
   /// both not null, and [CrossAxisAlignment.center] otherwise.
   /// {@endtemplate}
   final CrossAxisAlignment? crossAxisAlignment;
+
+  /// {@template ShadCheckbox.orderPolicy}
+  /// The order policy of the items that compose the checkbox, defaults to
+  /// [WidgetOrderPolicy.linear()].
+  /// {@endtemplate}
+  final WidgetOrderPolicy? orderPolicy;
 
   @override
   State<ShadCheckbox> createState() => _ShadCheckboxState();
@@ -133,6 +141,10 @@ class _ShadCheckboxState extends State<ShadCheckbox> {
     final effectivePadding = widget.padding ??
         theme.checkboxTheme.padding ??
         const EdgeInsets.only(left: 8);
+
+    final effectiveOrderPolicy = widget.orderPolicy ??
+        theme.checkboxTheme.orderPolicy ??
+        const WidgetOrderPolicy.linear();
 
     final checkbox = Semantics(
       checked: widget.value,
@@ -225,7 +237,7 @@ class _ShadCheckboxState extends State<ShadCheckbox> {
                   ),
                 ),
               ),
-          ],
+          ].order(effectiveOrderPolicy),
         ),
       ),
     );

--- a/lib/src/components/date_picker.dart
+++ b/lib/src/components/date_picker.dart
@@ -13,6 +13,7 @@ import 'package:shadcn_ui/src/raw_components/portal.dart';
 import 'package:shadcn_ui/src/theme/components/decorator.dart';
 import 'package:shadcn_ui/src/theme/theme.dart';
 import 'package:shadcn_ui/src/utils/extensions/date_time.dart';
+import 'package:shadcn_ui/src/utils/extensions/order_policy.dart';
 import 'package:shadcn_ui/src/utils/gesture_detector.dart';
 import 'package:shadcn_ui/src/utils/states_controller.dart';
 
@@ -155,6 +156,8 @@ class ShadDatePicker extends StatefulWidget {
     this.textDirection,
     this.onFocusChange,
     this.iconSrc,
+    this.orderPolicy,
+    this.expands,
   })  : variant = ShadDatePickerVariant.single,
         formatDateRange = null,
         selectedRange = null;
@@ -295,6 +298,8 @@ class ShadDatePicker extends StatefulWidget {
     this.textDirection,
     this.onFocusChange,
     this.iconSrc,
+    this.orderPolicy,
+    this.expands,
   })  : variant = ShadDatePickerVariant.range,
         selected = null,
         formatDate = null,
@@ -439,6 +444,8 @@ class ShadDatePicker extends StatefulWidget {
     this.iconSrc,
     this.formatDateRange,
     this.placeholder,
+    this.orderPolicy,
+    this.expands,
   });
 
   /// {@template ShadDatePicker.placeholder}
@@ -888,6 +895,12 @@ class ShadDatePicker extends StatefulWidget {
   /// {@macro ShadButton.onFocusChange}
   final ValueChanged<bool>? onFocusChange;
 
+  /// {@macro ShadButton.orderPolicy}
+  final WidgetOrderPolicy? orderPolicy;
+
+  /// {@macro ShadButton.expands}
+  final bool? expands;
+
   @override
   State<ShadDatePicker> createState() => _ShadDatePickerState();
 }
@@ -969,6 +982,13 @@ class _ShadDatePickerState extends State<ShadDatePicker> {
     final effectiveCalendarDecoration = widget.calendarDecoration ??
         theme.datePickerTheme.calendarDecoration ??
         ShadDecoration.none;
+
+    final effectiveOrderPolicy = widget.orderPolicy ??
+        theme.datePickerTheme.orderPolicy ??
+        const WidgetOrderPolicy.linear();
+
+    final effectiveExpands =
+        widget.expands ?? theme.datePickerTheme.expands ?? false;
 
     return ShadPopover(
       controller: popoverController,
@@ -1209,6 +1229,8 @@ class _ShadDatePickerState extends State<ShadDatePicker> {
         hoverStrategies:
             widget.hoverStrategies ?? theme.datePickerTheme.hoverStrategies,
         textDirection: widget.textDirection,
+        orderPolicy: effectiveOrderPolicy,
+        expands: effectiveExpands,
         child: widget.buttonChild ??
             (isSelected
                 ? Text(

--- a/lib/src/components/form/fields/checkbox.dart
+++ b/lib/src/components/form/fields/checkbox.dart
@@ -3,6 +3,7 @@ import 'package:shadcn_ui/src/components/checkbox.dart';
 import 'package:shadcn_ui/src/components/form/field.dart';
 import 'package:shadcn_ui/src/theme/components/decorator.dart';
 import 'package:shadcn_ui/src/theme/theme.dart';
+import 'package:shadcn_ui/src/utils/extensions/order_policy.dart';
 
 class ShadCheckboxFormField extends ShadFormBuilderField<bool> {
   ShadCheckboxFormField({
@@ -33,6 +34,9 @@ class ShadCheckboxFormField extends ShadFormBuilderField<bool> {
 
     /// {@macro ShadCheckbox.crossAxisAlignment}
     CrossAxisAlignment? crossAxisAlignment,
+
+    /// {@macro ShadCheckbox.orderPolicy}
+    WidgetOrderPolicy? orderPolicy,
   }) : super(
           initialValue: initialValue,
           onChanged: onChanged == null ? null : (v) => onChanged(v ?? false),
@@ -58,6 +62,7 @@ class ShadCheckboxFormField extends ShadFormBuilderField<bool> {
               direction: direction,
               decoration: state.decoration,
               crossAxisAlignment: crossAxisAlignment,
+              orderPolicy: orderPolicy,
             );
           },
         );

--- a/lib/src/components/form/fields/date_picker.dart
+++ b/lib/src/components/form/fields/date_picker.dart
@@ -11,6 +11,7 @@ import 'package:shadcn_ui/src/components/image.dart';
 import 'package:shadcn_ui/src/components/popover.dart';
 import 'package:shadcn_ui/src/raw_components/portal.dart';
 import 'package:shadcn_ui/src/theme/components/decorator.dart';
+import 'package:shadcn_ui/src/utils/extensions/order_policy.dart';
 import 'package:shadcn_ui/src/utils/gesture_detector.dart';
 import 'package:shadcn_ui/src/utils/states_controller.dart';
 
@@ -421,6 +422,12 @@ class ShadDatePickerFormField extends ShadFormBuilderField<DateTime> {
 
     /// {@macro ShadButton.onFocusChange}
     ValueChanged<bool>? onFocusChange,
+
+    /// {@macro ShadButton.orderPolicy}
+    WidgetOrderPolicy? orderPolicy,
+
+    /// {@macro ShadButton.expands}
+    bool? expands,
   }) : super(
           builder: (field) {
             final state = field as _ShadFormBuilderDatePickerState;
@@ -557,6 +564,8 @@ class ShadDatePickerFormField extends ShadFormBuilderField<DateTime> {
               textDirection: textDirection,
               onFocusChange: onFocusChange,
               placeholder: placeholder,
+              orderPolicy: orderPolicy,
+              expands: expands,
             );
           },
         );

--- a/lib/src/components/form/fields/date_range_picker.dart
+++ b/lib/src/components/form/fields/date_range_picker.dart
@@ -11,6 +11,7 @@ import 'package:shadcn_ui/src/components/image.dart';
 import 'package:shadcn_ui/src/components/popover.dart';
 import 'package:shadcn_ui/src/raw_components/portal.dart';
 import 'package:shadcn_ui/src/theme/components/decorator.dart';
+import 'package:shadcn_ui/src/utils/extensions/order_policy.dart';
 import 'package:shadcn_ui/src/utils/gesture_detector.dart';
 import 'package:shadcn_ui/src/utils/states_controller.dart';
 
@@ -428,6 +429,12 @@ class ShadDateRangePickerFormField
 
     /// {@macro ShadButton.onFocusChange}
     ValueChanged<bool>? onFocusChange,
+
+    /// {@macro ShadButton.orderPolicy}
+    WidgetOrderPolicy? orderPolicy,
+
+    /// {@macro ShadButton.expands}
+    bool? expands,
   }) : super(
           builder: (field) {
             final state = field as _ShadFormBuilderDateRangePickerState;
@@ -566,6 +573,8 @@ class ShadDateRangePickerFormField
               textDirection: textDirection,
               onFocusChange: onFocusChange,
               placeholder: placeholder,
+              orderPolicy: orderPolicy,
+              expands: expands,
             );
           },
         );

--- a/lib/src/components/form/fields/switch.dart
+++ b/lib/src/components/form/fields/switch.dart
@@ -3,6 +3,7 @@ import 'package:shadcn_ui/src/components/form/field.dart';
 import 'package:shadcn_ui/src/components/switch.dart';
 import 'package:shadcn_ui/src/theme/components/decorator.dart';
 import 'package:shadcn_ui/src/theme/theme.dart';
+import 'package:shadcn_ui/src/utils/extensions/order_policy.dart';
 
 class ShadSwitchFormField extends ShadFormBuilderField<bool> {
   ShadSwitchFormField({
@@ -32,6 +33,9 @@ class ShadSwitchFormField extends ShadFormBuilderField<bool> {
     Widget? inputSublabel,
     EdgeInsets? padding,
     TextDirection? direction,
+
+    /// {@macro ShadSwitch.orderPolicy}
+    WidgetOrderPolicy? orderPolicy,
   }) : super(
           initialValue: initialValue,
           onChanged: (!enabled || onChanged == null)
@@ -65,6 +69,7 @@ class ShadSwitchFormField extends ShadFormBuilderField<bool> {
               thumbColor: thumbColor,
               uncheckedTrackColor: uncheckedTrackColor,
               checkedTrackColor: checkedTrackColor,
+              orderPolicy: orderPolicy,
             );
           },
         );

--- a/lib/src/components/radio.dart
+++ b/lib/src/components/radio.dart
@@ -7,6 +7,7 @@ import 'package:shadcn_ui/src/raw_components/focusable.dart';
 import 'package:shadcn_ui/src/theme/components/decorator.dart';
 import 'package:shadcn_ui/src/theme/theme.dart';
 import 'package:shadcn_ui/src/utils/debug_check.dart';
+import 'package:shadcn_ui/src/utils/extensions/order_policy.dart';
 import 'package:shadcn_ui/src/utils/provider.dart';
 
 class ShadRadioGroup<T> extends StatefulWidget {
@@ -147,6 +148,7 @@ class ShadRadio<T> extends StatefulWidget {
     this.sublabel,
     this.padding,
     this.direction,
+    this.orderPolicy,
   });
 
   /// The value of the radio.
@@ -185,6 +187,12 @@ class ShadRadio<T> extends StatefulWidget {
 
   /// The direction of the radio.
   final TextDirection? direction;
+
+  /// {@template ShadRadio.orderPolicy}
+  /// The order policy of the items that compose the radio, defaults to
+  /// [WidgetOrderPolicy.linear()].
+  /// {@endtemplate}
+  final WidgetOrderPolicy? orderPolicy;
 
   @override
   State<ShadRadio<T>> createState() => _ShadRadioState<T>();
@@ -238,6 +246,10 @@ class _ShadRadioState<T> extends State<ShadRadio<T>> {
     final effectivePadding = widget.padding ??
         theme.radioTheme.padding ??
         const EdgeInsets.only(left: 8);
+
+    final effectiveOrderPolicy = widget.orderPolicy ??
+        theme.radioTheme.orderPolicy ??
+        const WidgetOrderPolicy.linear();
 
     final radio = Semantics(
       checked: selected,
@@ -327,7 +339,7 @@ class _ShadRadioState<T> extends State<ShadRadio<T>> {
                   ),
                 ),
               ),
-          ],
+          ].order(effectiveOrderPolicy),
         ),
       ),
     );

--- a/lib/src/components/select.dart
+++ b/lib/src/components/select.dart
@@ -16,6 +16,7 @@ import 'package:shadcn_ui/src/theme/components/decorator.dart';
 import 'package:shadcn_ui/src/theme/components/select.dart';
 import 'package:shadcn_ui/src/theme/theme.dart';
 import 'package:shadcn_ui/src/utils/debug_check.dart';
+import 'package:shadcn_ui/src/utils/extensions/order_policy.dart';
 import 'package:shadcn_ui/src/utils/gesture_detector.dart';
 import 'package:shadcn_ui/src/utils/provider.dart';
 
@@ -938,7 +939,7 @@ class ShadOption<T> extends StatefulWidget {
     this.padding,
     this.selectedIcon,
     this.radius,
-    this.placeSelectedIconFirst,
+    this.orderPolicy,
   });
 
   /// The value of the [ShadOption], it must be unique above the options.
@@ -961,10 +962,11 @@ class ShadOption<T> extends StatefulWidget {
   /// The radius of the [ShadOption], defaults to `ShadThemeData.radius`.
   final BorderRadius? radius;
 
-  /// {@template ShadOption.placeSelectedIconFirst}
-  /// Whether to place the icon first, defaults to true.
+  /// {@template ShadOption.orderPolicy}
+  /// The order policy of the selectedIcon and the child, defaults to
+  /// `LinearOrderPolicy`.
   /// {@endtemplate}
-  final bool? placeSelectedIconFirst;
+  final WidgetOrderPolicy? orderPolicy;
 
   @override
   State<ShadOption<T>> createState() => _ShadOptionState<T>();
@@ -1024,9 +1026,9 @@ class _ShadOptionState<T> extends State<ShadOption<T>> {
     final effectiveRadius =
         widget.radius ?? theme.optionTheme.radius ?? theme.radius;
 
-    final effectivePlaceSelectedIconFirst = widget.placeSelectedIconFirst ??
-        theme.selectTheme.optionsPlaceSelectedIconFirst ??
-        true;
+    final effectiveOrderPolicy = widget.orderPolicy ??
+        theme.selectTheme.optionsOrderPolicy ??
+        const WidgetOrderPolicy.linear();
 
     final effectiveSelectedIcon = widget.selectedIcon ??
         Visibility.maintain(
@@ -1070,7 +1072,7 @@ class _ShadOptionState<T> extends State<ShadOption<T>> {
             },
             child: Row(
               children: [
-                if (effectivePlaceSelectedIconFirst) effectiveSelectedIcon,
+                effectiveSelectedIcon,
                 Expanded(
                   child: DefaultTextStyle(
                     style: theme.textTheme.muted.copyWith(
@@ -1079,8 +1081,7 @@ class _ShadOptionState<T> extends State<ShadOption<T>> {
                     child: widget.child,
                   ),
                 ),
-                if (!effectivePlaceSelectedIconFirst) effectiveSelectedIcon,
-              ],
+              ].order(effectiveOrderPolicy),
             ),
           ),
         ),

--- a/lib/src/components/select.dart
+++ b/lib/src/components/select.dart
@@ -963,8 +963,8 @@ class ShadOption<T> extends StatefulWidget {
   final BorderRadius? radius;
 
   /// {@template ShadOption.orderPolicy}
-  /// The order policy of the selectedIcon and the child, defaults to
-  /// `LinearOrderPolicy`.
+  /// The order policy of the items that compose the option, defaults to
+  /// [WidgetOrderPolicy.linear()].
   /// {@endtemplate}
   final WidgetOrderPolicy? orderPolicy;
 

--- a/lib/src/components/switch.dart
+++ b/lib/src/components/switch.dart
@@ -6,6 +6,7 @@ import 'package:shadcn_ui/src/raw_components/focusable.dart';
 import 'package:shadcn_ui/src/theme/components/decorator.dart';
 import 'package:shadcn_ui/src/theme/theme.dart';
 import 'package:shadcn_ui/src/utils/debug_check.dart';
+import 'package:shadcn_ui/src/utils/extensions/order_policy.dart';
 
 class ShadSwitch extends StatefulWidget {
   const ShadSwitch({
@@ -26,6 +27,7 @@ class ShadSwitch extends StatefulWidget {
     this.label,
     this.sublabel,
     this.padding,
+    this.orderPolicy,
   });
 
   /// Whether the switch is on or off.
@@ -77,6 +79,12 @@ class ShadSwitch extends StatefulWidget {
 
   /// The direction of the switch.
   final TextDirection? direction;
+
+  /// {@template ShadSwitch.orderPolicy}
+  /// The order policy of the items that compose the switch, defaults to
+  /// [WidgetOrderPolicy.linear()].
+  /// {@endtemplate}
+  final WidgetOrderPolicy? orderPolicy;
 
   @override
   State<ShadSwitch> createState() => _ShadSwitchState();
@@ -151,6 +159,10 @@ class _ShadSwitchState extends State<ShadSwitch>
     final effectivePadding = widget.padding ??
         theme.switchTheme.padding ??
         const EdgeInsets.only(left: 8);
+
+    final effectiveOrderPolicy = widget.orderPolicy ??
+        theme.switchTheme.orderPolicy ??
+        const WidgetOrderPolicy.linear();
 
     final switchWidget = Semantics(
       toggled: widget.value,
@@ -255,7 +267,7 @@ class _ShadSwitchState extends State<ShadSwitch>
                   ),
                 ),
               ),
-          ],
+          ].order(effectiveOrderPolicy),
         ),
       ),
     );

--- a/lib/src/components/toast.dart
+++ b/lib/src/components/toast.dart
@@ -8,6 +8,7 @@ import 'package:shadcn_ui/src/components/button.dart';
 import 'package:shadcn_ui/src/components/image.dart';
 import 'package:shadcn_ui/src/theme/theme.dart';
 import 'package:shadcn_ui/src/theme/themes/shadows.dart';
+import 'package:shadcn_ui/src/utils/extensions/order_policy.dart';
 import 'package:shadcn_ui/src/utils/position.dart';
 import 'package:shadcn_ui/src/utils/responsive.dart';
 
@@ -276,6 +277,7 @@ class ShadToast extends StatefulWidget {
     this.padding,
     this.closeIconPosition,
     this.constraints,
+    this.orderPolicy,
   }) : variant = ShadToastVariant.primary;
 
   const ShadToast.destructive({
@@ -303,6 +305,7 @@ class ShadToast extends StatefulWidget {
     this.padding,
     this.closeIconPosition,
     this.constraints,
+    this.orderPolicy,
   }) : variant = ShadToastVariant.destructive;
 
   const ShadToast.raw({
@@ -331,6 +334,7 @@ class ShadToast extends StatefulWidget {
     this.padding,
     this.closeIconPosition,
     this.constraints,
+    this.orderPolicy,
   });
 
   final Widget? title;
@@ -357,6 +361,12 @@ class ShadToast extends StatefulWidget {
   final ShadPosition? closeIconPosition;
   final ShadToastVariant variant;
   final BoxConstraints? constraints;
+
+  /// {@template ShadToast.orderPolicy}
+  /// The order policy of the items that compose the toast, defaults to
+  /// [WidgetOrderPolicy.linear()].
+  /// {@endtemplate}
+  final WidgetOrderPolicy? orderPolicy;
 
   @override
   State<ShadToast> createState() => _ShadToastState();
@@ -439,6 +449,10 @@ class _ShadToastState extends State<ShadToast> {
             effectiveToastTheme.showCloseIconOnlyWhenHovered ??
             true;
 
+    final effectiveOrderPolicy = widget.orderPolicy ??
+        effectiveToastTheme.orderPolicy ??
+        const WidgetOrderPolicy.linear();
+
     return MouseRegion(
       onEnter: (_) => hovered.value = true,
       onExit: (_) => hovered.value = false,
@@ -490,7 +504,7 @@ class _ShadToastState extends State<ShadToast> {
                             padding: effectiveActionPadding,
                             child: widget.action,
                           ),
-                      ],
+                      ].order(effectiveOrderPolicy),
                     ),
                   ),
                   ValueListenableBuilder(

--- a/lib/src/theme/components/alert.dart
+++ b/lib/src/theme/components/alert.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/src/theme/components/decorator.dart';
+import 'package:shadcn_ui/src/utils/extensions/order_policy.dart';
 
 @immutable
 class ShadAlertTheme {
@@ -13,6 +14,7 @@ class ShadAlertTheme {
     this.descriptionStyle,
     this.mainAxisAlignment,
     this.crossAxisAlignment,
+    this.orderPolicy,
   });
 
   final bool merge;
@@ -24,6 +26,9 @@ class ShadAlertTheme {
   final TextStyle? descriptionStyle;
   final MainAxisAlignment? mainAxisAlignment;
   final CrossAxisAlignment? crossAxisAlignment;
+
+  /// {@macro ShadAlert.orderPolicy}
+  final WidgetOrderPolicy? orderPolicy;
 
   static ShadAlertTheme lerp(
     ShadAlertTheme a,
@@ -42,6 +47,7 @@ class ShadAlertTheme {
           TextStyle.lerp(a.descriptionStyle, b.descriptionStyle, t),
       mainAxisAlignment: t < 0.5 ? a.mainAxisAlignment : b.mainAxisAlignment,
       crossAxisAlignment: t < 0.5 ? a.crossAxisAlignment : b.crossAxisAlignment,
+      orderPolicy: t < .5 ? a.orderPolicy : b.orderPolicy,
     );
   }
 
@@ -55,6 +61,7 @@ class ShadAlertTheme {
     TextStyle? descriptionStyle,
     MainAxisAlignment? mainAxisAlignment,
     CrossAxisAlignment? crossAxisAlignment,
+    WidgetOrderPolicy? orderPolicy,
   }) {
     return ShadAlertTheme(
       merge: merge ?? this.merge,
@@ -66,6 +73,7 @@ class ShadAlertTheme {
       descriptionStyle: descriptionStyle ?? this.descriptionStyle,
       mainAxisAlignment: mainAxisAlignment ?? this.mainAxisAlignment,
       crossAxisAlignment: crossAxisAlignment ?? this.crossAxisAlignment,
+      orderPolicy: orderPolicy ?? this.orderPolicy,
     );
   }
 
@@ -81,6 +89,7 @@ class ShadAlertTheme {
       descriptionStyle: other.descriptionStyle,
       mainAxisAlignment: other.mainAxisAlignment,
       crossAxisAlignment: other.crossAxisAlignment,
+      orderPolicy: other.orderPolicy,
     );
   }
 
@@ -97,7 +106,8 @@ class ShadAlertTheme {
         other.titleStyle == titleStyle &&
         other.descriptionStyle == descriptionStyle &&
         other.mainAxisAlignment == mainAxisAlignment &&
-        other.crossAxisAlignment == crossAxisAlignment;
+        other.crossAxisAlignment == crossAxisAlignment &&
+        other.orderPolicy == orderPolicy;
   }
 
   @override
@@ -110,6 +120,7 @@ class ShadAlertTheme {
         titleStyle.hashCode ^
         descriptionStyle.hashCode ^
         mainAxisAlignment.hashCode ^
-        crossAxisAlignment.hashCode;
+        crossAxisAlignment.hashCode ^
+        orderPolicy.hashCode;
   }
 }

--- a/lib/src/theme/components/button.dart
+++ b/lib/src/theme/components/button.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/src/components/button.dart';
 import 'package:shadcn_ui/src/theme/components/decorator.dart';
+import 'package:shadcn_ui/src/utils/extensions/order_policy.dart';
 import 'package:shadcn_ui/src/utils/gesture_detector.dart';
 
 /// The theme for ShadButton.
@@ -37,6 +38,8 @@ class ShadButtonTheme {
     this.hoverStrategies,
     this.textDirection,
     this.gap,
+    this.orderPolicy,
+    this.expands,
   });
 
   final bool merge;
@@ -69,6 +72,12 @@ class ShadButtonTheme {
 
   /// {@macro ShadButton.gap}
   final double? gap;
+
+  /// {@macro ShadButton.orderPolicy}
+  final WidgetOrderPolicy? orderPolicy;
+
+  /// {@macro ShadButton.expands}
+  final bool? expands;
 
   static ShadButtonTheme lerp(
     ShadButtonTheme a,
@@ -113,6 +122,8 @@ class ShadButtonTheme {
       hoverStrategies: t < 0.5 ? a.hoverStrategies : b.hoverStrategies,
       textDirection: t < 0.5 ? a.textDirection : b.textDirection,
       gap: t < 0.5 ? a.gap : b.gap,
+      orderPolicy: t < .5 ? a.orderPolicy : b.orderPolicy,
+      expands: t < .5 ? a.expands : b.expands,
     );
   }
 
@@ -141,6 +152,8 @@ class ShadButtonTheme {
     ShadHoverStrategies? hoverStrategies,
     TextDirection? textDirection,
     double? gap,
+    WidgetOrderPolicy? orderPolicy,
+    bool? expands,
   }) {
     return ShadButtonTheme(
       applyIconColorFilter: applyIconColorFilter ?? this.applyIconColorFilter,
@@ -168,6 +181,8 @@ class ShadButtonTheme {
       hoverStrategies: hoverStrategies ?? this.hoverStrategies,
       textDirection: textDirection ?? this.textDirection,
       gap: gap ?? this.gap,
+      orderPolicy: orderPolicy ?? this.orderPolicy,
+      expands: expands ?? this.expands,
     );
   }
 
@@ -197,6 +212,8 @@ class ShadButtonTheme {
       hoverStrategies: other.hoverStrategies,
       textDirection: other.textDirection,
       gap: other.gap,
+      orderPolicy: other.orderPolicy,
+      expands: other.expands,
     );
   }
 
@@ -228,7 +245,9 @@ class ShadButtonTheme {
         other.longPressDuration == longPressDuration &&
         other.hoverStrategies == hoverStrategies &&
         other.textDirection == textDirection &&
-        other.gap == gap;
+        other.gap == gap &&
+        other.orderPolicy == orderPolicy &&
+        other.expands == expands;
   }
 
   @override
@@ -256,7 +275,9 @@ class ShadButtonTheme {
         longPressDuration.hashCode ^
         hoverStrategies.hashCode ^
         textDirection.hashCode ^
-        gap.hashCode;
+        gap.hashCode ^
+        orderPolicy.hashCode ^
+        expands.hashCode;
   }
 }
 

--- a/lib/src/theme/components/checkbox.dart
+++ b/lib/src/theme/components/checkbox.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 import 'package:flutter/widgets.dart';
 
 import 'package:shadcn_ui/src/theme/components/decorator.dart';
+import 'package:shadcn_ui/src/utils/extensions/order_policy.dart';
 
 @immutable
 class ShadCheckboxTheme {
@@ -14,6 +15,7 @@ class ShadCheckboxTheme {
     this.size,
     this.padding,
     this.crossAxisAlignment,
+    this.orderPolicy,
   });
 
   final bool merge;
@@ -28,8 +30,11 @@ class ShadCheckboxTheme {
 
   final EdgeInsets? padding;
 
-  /// {@macro ShadCheckboxTheme.crossAxisAlignment}
+  /// {@macro ShadCheckbox.crossAxisAlignment}
   final CrossAxisAlignment? crossAxisAlignment;
+
+  /// {@macro ShadCheckbox.orderPolicy}
+  final WidgetOrderPolicy? orderPolicy;
 
   static ShadCheckboxTheme lerp(
     ShadCheckboxTheme a,
@@ -45,6 +50,7 @@ class ShadCheckboxTheme {
       size: lerpDouble(a.size, b.size, t),
       padding: EdgeInsets.lerp(a.padding, b.padding, t),
       crossAxisAlignment: t < .5 ? a.crossAxisAlignment : b.crossAxisAlignment,
+      orderPolicy: t < .5 ? a.orderPolicy : b.orderPolicy,
     );
   }
 
@@ -56,6 +62,7 @@ class ShadCheckboxTheme {
     ShadDecoration? decoration,
     EdgeInsets? padding,
     CrossAxisAlignment? crossAxisAlignment,
+    WidgetOrderPolicy? orderPolicy,
   }) {
     return ShadCheckboxTheme(
       merge: merge ?? this.merge,
@@ -65,6 +72,7 @@ class ShadCheckboxTheme {
       color: color ?? this.color,
       padding: padding ?? this.padding,
       crossAxisAlignment: crossAxisAlignment ?? this.crossAxisAlignment,
+      orderPolicy: orderPolicy ?? this.orderPolicy,
     );
   }
 
@@ -78,6 +86,7 @@ class ShadCheckboxTheme {
       size: other.size,
       padding: other.padding,
       crossAxisAlignment: other.crossAxisAlignment,
+      orderPolicy: other.orderPolicy,
     );
   }
 
@@ -92,7 +101,8 @@ class ShadCheckboxTheme {
         other.duration == duration &&
         other.decoration == decoration &&
         other.padding == padding &&
-        other.crossAxisAlignment == crossAxisAlignment;
+        other.crossAxisAlignment == crossAxisAlignment &&
+        other.orderPolicy == orderPolicy;
   }
 
   @override
@@ -103,6 +113,7 @@ class ShadCheckboxTheme {
         duration.hashCode ^
         decoration.hashCode ^
         padding.hashCode ^
-        crossAxisAlignment.hashCode;
+        crossAxisAlignment.hashCode ^
+        orderPolicy.hashCode;
   }
 }

--- a/lib/src/theme/components/date_picker.dart
+++ b/lib/src/theme/components/date_picker.dart
@@ -3,8 +3,14 @@ import 'dart:ui';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_animate/flutter_animate.dart';
-
-import 'package:shadcn_ui/shadcn_ui.dart';
+import 'package:shadcn_ui/src/components/button.dart';
+import 'package:shadcn_ui/src/components/calendar.dart';
+import 'package:shadcn_ui/src/components/image.dart';
+import 'package:shadcn_ui/src/raw_components/portal.dart';
+import 'package:shadcn_ui/src/theme/components/button.dart';
+import 'package:shadcn_ui/src/theme/components/decorator.dart';
+import 'package:shadcn_ui/src/utils/extensions/order_policy.dart';
+import 'package:shadcn_ui/src/utils/gesture_detector.dart';
 
 @immutable
 class ShadDatePickerTheme {
@@ -98,6 +104,8 @@ class ShadDatePickerTheme {
     this.formatDateRange,
     this.buttonPadding,
     this.iconSrc,
+    this.orderPolicy,
+    this.expands,
   });
 
   final bool merge;
@@ -378,6 +386,12 @@ class ShadDatePickerTheme {
   /// {@macro ShadButton.padding}
   final EdgeInsetsGeometry? buttonPadding;
 
+  /// {@macro ShadButton.orderPolicy}
+  final WidgetOrderPolicy? orderPolicy;
+
+  /// {@macro ShadButton.expands}
+  final bool? expands;
+
   static ShadDatePickerTheme lerp(
     ShadDatePickerTheme a,
     ShadDatePickerTheme b,
@@ -589,6 +603,8 @@ class ShadDatePickerTheme {
       buttonPadding:
           EdgeInsetsGeometry.lerp(a.buttonPadding, b.buttonPadding, t),
       iconSrc: t < 0.5 ? a.iconSrc : b.iconSrc,
+      orderPolicy: t < .5 ? a.orderPolicy : b.orderPolicy,
+      expands: t < .5 ? a.expands : b.expands,
     );
   }
 
@@ -705,6 +721,8 @@ class ShadDatePickerTheme {
       buttonVariant: other.buttonVariant,
       buttonPadding: other.buttonPadding,
       iconSrc: other.iconSrc,
+      orderPolicy: other.orderPolicy,
+      expands: other.expands,
     );
   }
 
@@ -803,7 +821,9 @@ class ShadDatePickerTheme {
         other.formatDateRange == formatDateRange &&
         other.buttonVariant == buttonVariant &&
         other.buttonPadding == buttonPadding &&
-        other.iconSrc == iconSrc;
+        other.iconSrc == iconSrc &&
+        other.orderPolicy == orderPolicy &&
+        other.expands == expands;
   }
 
   @override
@@ -895,7 +915,9 @@ class ShadDatePickerTheme {
         formatDateRange.hashCode ^
         buttonVariant.hashCode ^
         buttonPadding.hashCode ^
-        iconSrc.hashCode;
+        iconSrc.hashCode ^
+        orderPolicy.hashCode ^
+        expands.hashCode;
   }
 
   ShadDatePickerTheme copyWith({
@@ -990,6 +1012,8 @@ class ShadDatePickerTheme {
     ShadButtonVariant? buttonVariant,
     EdgeInsetsGeometry? buttonPadding,
     ShadImageSrc? iconSrc,
+    WidgetOrderPolicy? orderPolicy,
+    bool? expands,
   }) {
     return ShadDatePickerTheme(
       merge: merge ?? this.merge,
@@ -1102,6 +1126,8 @@ class ShadDatePickerTheme {
       buttonVariant: buttonVariant ?? this.buttonVariant,
       buttonPadding: buttonPadding ?? this.buttonPadding,
       iconSrc: iconSrc ?? this.iconSrc,
+      orderPolicy: orderPolicy ?? this.orderPolicy,
+      expands: expands ?? this.expands,
     );
   }
 }

--- a/lib/src/theme/components/radio.dart
+++ b/lib/src/theme/components/radio.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 import 'package:flutter/widgets.dart';
 
 import 'package:shadcn_ui/src/theme/components/decorator.dart';
+import 'package:shadcn_ui/src/utils/extensions/order_policy.dart';
 
 @immutable
 class ShadRadioTheme {
@@ -20,6 +21,7 @@ class ShadRadioTheme {
     this.alignment,
     this.runAlignment,
     this.crossAxisAlignment,
+    this.orderPolicy,
   });
 
   final bool merge;
@@ -53,6 +55,9 @@ class ShadRadioTheme {
 
   /// {@macro ShadRadioGroup.crossAxisAlignment}
   final WrapCrossAlignment? crossAxisAlignment;
+
+  /// {@macro ShadRadio.orderPolicy}
+  final WidgetOrderPolicy? orderPolicy;
 
   static ShadRadioTheme lerp(
     ShadRadioTheme a,
@@ -91,6 +96,7 @@ class ShadRadioTheme {
     WrapAlignment? alignment,
     WrapAlignment? runAlignment,
     WrapCrossAlignment? crossAxisAlignment,
+    WidgetOrderPolicy? orderPolicy,
   }) {
     return ShadRadioTheme(
       merge: merge ?? this.merge,
@@ -106,6 +112,7 @@ class ShadRadioTheme {
       alignment: alignment ?? this.alignment,
       runAlignment: runAlignment ?? this.runAlignment,
       crossAxisAlignment: crossAxisAlignment ?? this.crossAxisAlignment,
+      orderPolicy: orderPolicy ?? this.orderPolicy,
     );
   }
 
@@ -125,6 +132,7 @@ class ShadRadioTheme {
       alignment: other.alignment,
       runAlignment: other.runAlignment,
       crossAxisAlignment: other.crossAxisAlignment,
+      orderPolicy: other.orderPolicy,
     );
   }
 
@@ -145,7 +153,8 @@ class ShadRadioTheme {
         other.runSpacing == runSpacing &&
         other.alignment == alignment &&
         other.runAlignment == runAlignment &&
-        other.crossAxisAlignment == crossAxisAlignment;
+        other.crossAxisAlignment == crossAxisAlignment &&
+        other.orderPolicy == orderPolicy;
   }
 
   @override
@@ -162,6 +171,7 @@ class ShadRadioTheme {
         runSpacing.hashCode ^
         alignment.hashCode ^
         runAlignment.hashCode ^
-        crossAxisAlignment.hashCode;
+        crossAxisAlignment.hashCode ^
+        orderPolicy.hashCode;
   }
 }

--- a/lib/src/theme/components/select.dart
+++ b/lib/src/theme/components/select.dart
@@ -4,6 +4,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:shadcn_ui/src/raw_components/portal.dart';
 import 'package:shadcn_ui/src/theme/components/decorator.dart';
+import 'package:shadcn_ui/src/utils/extensions/order_policy.dart';
 
 const kDefaultSelectMinWidth = 128.0;
 const kDefaultSelectMaxHeight = 384.0;
@@ -26,7 +27,7 @@ class ShadSelectTheme {
     this.effects,
     this.shadows,
     this.filter,
-    this.optionsPlaceSelectedIconFirst,
+    this.optionsOrderPolicy,
   });
 
   final bool merge;
@@ -51,8 +52,8 @@ class ShadSelectTheme {
   /// {@macro popover.shadows}
   final List<BoxShadow>? shadows;
 
-  /// {@macro ShadOption.placeSelectedIconFirst}
-  final bool? optionsPlaceSelectedIconFirst;
+  /// {@macro ShadOption.orderPolicy}
+  final WidgetOrderPolicy? optionsOrderPolicy;
 
   static ShadSelectTheme lerp(
     ShadSelectTheme a,
@@ -77,9 +78,7 @@ class ShadSelectTheme {
       clearSearchOnClose: t < 0.5 ? a.clearSearchOnClose : b.clearSearchOnClose,
       effects: t < 0.5 ? a.effects : b.effects,
       shadows: t < 0.5 ? a.shadows : b.shadows,
-      optionsPlaceSelectedIconFirst: t < .5
-          ? a.optionsPlaceSelectedIconFirst
-          : b.optionsPlaceSelectedIconFirst,
+      optionsOrderPolicy: t < .5 ? a.optionsOrderPolicy : b.optionsOrderPolicy,
     );
   }
 
@@ -101,7 +100,7 @@ class ShadSelectTheme {
     List<Effect<dynamic>>? effects,
     List<BoxShadow>? shadows,
     ImageFilter? filter,
-    bool? optionsPlaceSelectedIconFirst,
+    WidgetOrderPolicy? optionsOrderPolicy,
   }) {
     return ShadSelectTheme(
       merge: merge ?? this.merge,
@@ -121,8 +120,7 @@ class ShadSelectTheme {
       effects: effects ?? this.effects,
       shadows: shadows ?? this.shadows,
       filter: filter ?? this.filter,
-      optionsPlaceSelectedIconFirst:
-          optionsPlaceSelectedIconFirst ?? this.optionsPlaceSelectedIconFirst,
+      optionsOrderPolicy: optionsOrderPolicy ?? this.optionsOrderPolicy,
     );
   }
 
@@ -144,7 +142,7 @@ class ShadSelectTheme {
       effects: other.effects,
       shadows: other.shadows,
       filter: other.filter,
-      optionsPlaceSelectedIconFirst: other.optionsPlaceSelectedIconFirst,
+      optionsOrderPolicy: other.optionsOrderPolicy,
     );
   }
 
@@ -168,7 +166,7 @@ class ShadSelectTheme {
         other.effects == effects &&
         other.shadows == shadows &&
         other.filter == filter &&
-        other.optionsPlaceSelectedIconFirst == optionsPlaceSelectedIconFirst;
+        other.optionsOrderPolicy == optionsOrderPolicy;
   }
 
   @override
@@ -188,6 +186,6 @@ class ShadSelectTheme {
         effects.hashCode ^
         shadows.hashCode ^
         filter.hashCode ^
-        optionsPlaceSelectedIconFirst.hashCode;
+        optionsOrderPolicy.hashCode;
   }
 }

--- a/lib/src/theme/components/switch.dart
+++ b/lib/src/theme/components/switch.dart
@@ -2,6 +2,7 @@ import 'dart:ui';
 
 import 'package:flutter/widgets.dart';
 import 'package:shadcn_ui/src/theme/components/decorator.dart';
+import 'package:shadcn_ui/src/utils/extensions/order_policy.dart';
 
 @immutable
 class ShadSwitchTheme {
@@ -16,6 +17,7 @@ class ShadSwitchTheme {
     this.duration,
     this.decoration,
     this.padding,
+    this.orderPolicy,
   });
 
   final bool merge;
@@ -38,6 +40,9 @@ class ShadSwitchTheme {
 
   final EdgeInsets? padding;
 
+  /// {@macro ShadSwitch.orderPolicy}
+  final WidgetOrderPolicy? orderPolicy;
+
   static ShadSwitchTheme lerp(
     ShadSwitchTheme a,
     ShadSwitchTheme b,
@@ -57,6 +62,7 @@ class ShadSwitchTheme {
       duration: b.duration,
       decoration: ShadDecoration.lerp(a.decoration, b.decoration, t),
       padding: EdgeInsets.lerp(a.padding, b.padding, t),
+      orderPolicy: t < .5 ? a.orderPolicy : b.orderPolicy,
     );
   }
 
@@ -71,6 +77,7 @@ class ShadSwitchTheme {
     Duration? duration,
     ShadDecoration? decoration,
     EdgeInsets? padding,
+    WidgetOrderPolicy? orderPolicy,
   }) {
     return ShadSwitchTheme(
       merge: merge ?? this.merge,
@@ -83,6 +90,7 @@ class ShadSwitchTheme {
       duration: duration ?? this.duration,
       decoration: decoration ?? this.decoration,
       padding: padding ?? this.padding,
+      orderPolicy: orderPolicy ?? this.orderPolicy,
     );
   }
 
@@ -99,6 +107,7 @@ class ShadSwitchTheme {
       duration: other.duration,
       decoration: decoration?.mergeWith(other.decoration) ?? other.decoration,
       padding: other.padding,
+      orderPolicy: other.orderPolicy,
     );
   }
 
@@ -116,7 +125,8 @@ class ShadSwitchTheme {
         other.margin == margin &&
         other.duration == duration &&
         other.decoration == decoration &&
-        other.padding == padding;
+        other.padding == padding &&
+        other.orderPolicy == orderPolicy;
   }
 
   @override
@@ -130,6 +140,7 @@ class ShadSwitchTheme {
         margin.hashCode ^
         duration.hashCode ^
         decoration.hashCode ^
-        padding.hashCode;
+        padding.hashCode ^
+        orderPolicy.hashCode;
   }
 }

--- a/lib/src/theme/components/toast.dart
+++ b/lib/src/theme/components/toast.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_animate/flutter_animate.dart';
 import 'package:shadcn_ui/src/components/image.dart';
+import 'package:shadcn_ui/src/utils/extensions/order_policy.dart';
 
 import 'package:shadcn_ui/src/utils/position.dart';
 
@@ -28,6 +29,7 @@ class ShadToastTheme {
     this.padding,
     this.closeIconPosition,
     this.constraints,
+    this.orderPolicy,
   });
 
   final bool merge;
@@ -50,6 +52,7 @@ class ShadToastTheme {
   final EdgeInsets? padding;
   final ShadPosition? closeIconPosition;
   final BoxConstraints? constraints;
+  final WidgetOrderPolicy? orderPolicy;
 
   static ShadToastTheme lerp(
     ShadToastTheme a,
@@ -60,26 +63,29 @@ class ShadToastTheme {
     return ShadToastTheme(
       merge: b.merge,
       backgroundColor: Color.lerp(a.backgroundColor, b.backgroundColor, t),
-      closeIconSrc: b.closeIconSrc,
+      closeIconSrc: t < .5 ? a.closeIconSrc : b.closeIconSrc,
       alignment: Alignment.lerp(a.alignment, b.alignment, t),
       offset: Offset.lerp(a.offset, b.offset, t),
-      duration: b.duration,
-      animateIn: b.animateIn,
-      animateOut: b.animateOut,
-      textDirection: b.textDirection,
-      crossAxisAlignment: b.crossAxisAlignment,
-      showCloseIconOnlyWhenHovered: b.showCloseIconOnlyWhenHovered,
+      duration: t < .5 ? a.duration : b.duration,
+      animateIn: t < .5 ? a.animateIn : b.animateIn,
+      animateOut: t < .5 ? a.animateOut : b.animateOut,
+      textDirection: t < .5 ? a.textDirection : b.textDirection,
+      crossAxisAlignment: t < .5 ? a.crossAxisAlignment : b.crossAxisAlignment,
+      showCloseIconOnlyWhenHovered: t < .5
+          ? a.showCloseIconOnlyWhenHovered
+          : b.showCloseIconOnlyWhenHovered,
       titleStyle: TextStyle.lerp(a.titleStyle, b.titleStyle, t),
       descriptionStyle:
           TextStyle.lerp(a.descriptionStyle, b.descriptionStyle, t),
       actionPadding: EdgeInsets.lerp(a.actionPadding, b.actionPadding, t),
       border: Border.lerp(a.border, b.border, t),
       radius: BorderRadius.lerp(a.radius, b.radius, t),
-      shadows: b.shadows,
+      shadows: t < .5 ? a.shadows : b.shadows,
       padding: EdgeInsets.lerp(a.padding, b.padding, t),
       closeIconPosition:
           ShadPosition.lerp(a.closeIconPosition, b.closeIconPosition, t),
-      constraints: b.constraints,
+      constraints: t < .5 ? a.constraints : b.constraints,
+      orderPolicy: t < .5 ? a.orderPolicy : b.orderPolicy,
     );
   }
 
@@ -104,6 +110,7 @@ class ShadToastTheme {
     EdgeInsets? padding,
     ShadPosition? closeIconPosition,
     BoxConstraints? constraints,
+    WidgetOrderPolicy? orderPolicy,
   }) {
     return ShadToastTheme(
       merge: merge ?? this.merge,
@@ -127,6 +134,7 @@ class ShadToastTheme {
       padding: padding ?? this.padding,
       closeIconPosition: closeIconPosition ?? this.closeIconPosition,
       constraints: constraints ?? this.constraints,
+      orderPolicy: orderPolicy ?? this.orderPolicy,
     );
   }
 
@@ -153,6 +161,7 @@ class ShadToastTheme {
       padding: other.padding,
       closeIconPosition: other.closeIconPosition,
       constraints: other.constraints,
+      orderPolicy: other.orderPolicy,
     );
   }
 
@@ -180,7 +189,8 @@ class ShadToastTheme {
         listEquals(other.shadows, shadows) &&
         other.padding == padding &&
         other.closeIconPosition == closeIconPosition &&
-        other.constraints == constraints;
+        other.constraints == constraints &&
+        other.orderPolicy == orderPolicy;
   }
 
   @override
@@ -204,6 +214,7 @@ class ShadToastTheme {
         shadows.hashCode ^
         padding.hashCode ^
         closeIconPosition.hashCode ^
-        constraints.hashCode;
+        constraints.hashCode ^
+        orderPolicy.hashCode;
   }
 }

--- a/lib/src/utils/extensions/order_policy.dart
+++ b/lib/src/utils/extensions/order_policy.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/widgets.dart';
+
+typedef WidgetOrderPolicy = OrderPolicy<Widget>;
+typedef LinearWidgetOrderPolicy = LinearOrderPolicy<Widget>;
+typedef ReverseWidgetOrderPolicy = ReverseOrderPolicy<Widget>;
+typedef CustomWidgetOrderPolicy = CustomOrderPolicy<Widget>;
+
+/// Defines the order policy of a list of items.
+// ignore: one_member_abstracts
+abstract class OrderPolicy<T> {
+  const OrderPolicy();
+
+  /// {@macro LinearOrderPolicy}
+  const factory OrderPolicy.linear() = LinearOrderPolicy<T>;
+
+  /// {@macro ReverseOrderPolicy}
+  const factory OrderPolicy.reverse() = ReverseOrderPolicy<T>;
+
+  /// {@macro CustomOrderPolicy}
+  const factory OrderPolicy.custom({required List<int> indexes}) =
+      CustomOrderPolicy<T>;
+
+  List<T> order(List<T> items);
+}
+
+/// {@template LinearOrderPolicy}
+/// A linear order policy, keeps the order of the items as they are
+/// {@endtemplate}
+class LinearOrderPolicy<T> extends OrderPolicy<T> {
+  const LinearOrderPolicy();
+
+  @override
+  List<T> order(List<T> items) => items;
+}
+
+/// {@template ReverseOrderPolicy}
+/// A reverse order policy, reverses the order of the items
+/// {@endtemplate}
+class ReverseOrderPolicy<T> extends OrderPolicy<T> {
+  const ReverseOrderPolicy();
+
+  @override
+  List<T> order(List<T> items) => items.reversed.toList();
+}
+
+/// {@template CustomOrderPolicy}
+/// A custom order policy, orders the items based on the provided indexes
+/// For example an indexes value of [2, 0, 1] will order the items as follows:
+/// [last, first, second]
+/// {@endtemplate}
+class CustomOrderPolicy<T> extends OrderPolicy<T> {
+  const CustomOrderPolicy({required this.indexes});
+
+  final List<int> indexes;
+
+  @override
+  List<T> order(List<T> items) {
+    final orderedItems = <T>[];
+
+    for (final index in indexes) {
+      if (index >= 0 && index < items.length) {
+        orderedItems.add(items[index]);
+      } else {
+        throw IndexError.withLength(
+          index,
+          items.length,
+          message: 'Index is out of bounds',
+        );
+      }
+    }
+
+    return orderedItems;
+  }
+}
+
+extension WidgetsOrderPolicy on List<Widget> {
+  List<Widget> order(OrderPolicy<Widget> orderPolicy) {
+    return orderPolicy.order(this);
+  }
+}


### PR DESCRIPTION
- **FEAT**: New `OrderPolicy`, `LinearOrderPolicy`, `ReverseOrderPolicy` and `CustomOrderPolicy` to update the order policy of the items in a list, this can be very useful to arrange the order of the parts of the shadcn components.
- **FEAT**: Add `orderPolicy` to `ShadOption`, `ShadAlert`, `ShadButton`, `ShadCheckbox`, `ShadCheckboxFormField`, `ShadDatePicker`, `ShadDatePickerFormField`, `ShadDateRangePickerFormField`, `ShadRadio`, `ShadSwitch`, `ShadSwitchFormField`, `ShadToast`.
- **FEAT**: Add `expands` to `ShadButton`, defaults to false. Use it if you want the button's child to expand to fill the available space.
