### PR TITLE
Improve material/cupertino builder design - Rename function

### DIFF
--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -21,6 +21,37 @@ enum ShadAppType {
   custom,
 }
 
+typedef MaterialThemeBuilder = ThemeData Function(
+  BuildContext context,
+  ShadThemeData themeData,
+  String fontFamily,
+  Iterable<ThemeExtension<dynamic>>? extensions,
+  Brightness brightness,
+  Color primaryColor,
+  Color onPrimaryColor,
+  Color secondaryColor,
+  Color onSecondaryColor,
+  Color errorColor,
+  Color onErrorColor,
+  Color backgroundColor,
+  Color onBackgroundColor,
+  Color surfaceColor,
+  Color onSurfaceColor,
+  Color scaffoldBackgroundColor,
+  DividerThemeData dividerTheme,
+  TextSelectionThemeData textSelectionTheme,
+);
+
+typedef CupertinoThemeBuilder = CupertinoThemeData Function(
+  BuildContext context,
+  ShadThemeData themeData,
+  Brightness brightness,
+  Color primaryColor,
+  Color primaryContrastingColor,
+  Color scaffoldBackgroundColor,
+  Color barBackgroundColor,
+);
+
 class ShadApp extends StatefulWidget {
   /// Creates a [ShadApp] providing a [ShadTheme].
   const ShadApp({
@@ -54,13 +85,13 @@ class ShadApp extends StatefulWidget {
     this.scrollBehavior = const ShadScrollBehavior(),
     this.pageRouteBuilder,
     this.themeCurve = Curves.linear,
-    this.materialThemeBuilder,
+    this.materialThemeBuilder = defaultMaterialThemeBuilder,
   })  : routeInformationProvider = null,
         routeInformationParser = null,
         routerDelegate = null,
         backButtonDispatcher = null,
         routerConfig = null,
-        cupertinoThemeBuilder = null,
+        cupertinoThemeBuilder = defaultCupertinoThemeBuilder,
         appBuilder = null,
         type = ShadAppType.shadcn;
 
@@ -92,7 +123,7 @@ class ShadApp extends StatefulWidget {
     this.restorationScopeId,
     this.scrollBehavior = const ShadScrollBehavior(),
     this.themeCurve = Curves.linear,
-    this.materialThemeBuilder,
+    this.materialThemeBuilder = defaultMaterialThemeBuilder,
   })  : navigatorObservers = null,
         navigatorKey = null,
         onGenerateRoute = null,
@@ -102,7 +133,7 @@ class ShadApp extends StatefulWidget {
         routes = null,
         initialRoute = null,
         pageRouteBuilder = null,
-        cupertinoThemeBuilder = null,
+        cupertinoThemeBuilder = defaultCupertinoThemeBuilder,
         appBuilder = null,
         type = ShadAppType.shadcn;
 
@@ -138,13 +169,13 @@ class ShadApp extends StatefulWidget {
     this.scrollBehavior = const MaterialScrollBehavior(),
     this.pageRouteBuilder,
     this.themeCurve = Curves.linear,
-    this.materialThemeBuilder,
+    this.materialThemeBuilder = defaultMaterialThemeBuilder,
   })  : routeInformationProvider = null,
         routeInformationParser = null,
         routerDelegate = null,
         backButtonDispatcher = null,
         routerConfig = null,
-        cupertinoThemeBuilder = null,
+        cupertinoThemeBuilder = defaultCupertinoThemeBuilder,
         appBuilder = null,
         type = ShadAppType.material;
 
@@ -176,7 +207,7 @@ class ShadApp extends StatefulWidget {
     this.restorationScopeId,
     this.scrollBehavior = const MaterialScrollBehavior(),
     this.themeCurve = Curves.linear,
-    this.materialThemeBuilder,
+    this.materialThemeBuilder = defaultMaterialThemeBuilder,
   })  : navigatorObservers = null,
         navigatorKey = null,
         onGenerateRoute = null,
@@ -186,7 +217,7 @@ class ShadApp extends StatefulWidget {
         routes = null,
         initialRoute = null,
         pageRouteBuilder = null,
-        cupertinoThemeBuilder = null,
+        cupertinoThemeBuilder = defaultCupertinoThemeBuilder,
         appBuilder = null,
         type = ShadAppType.material;
 
@@ -222,8 +253,8 @@ class ShadApp extends StatefulWidget {
     this.scrollBehavior = const CupertinoScrollBehavior(),
     this.pageRouteBuilder,
     this.themeCurve = Curves.linear,
-    this.cupertinoThemeBuilder,
-    this.materialThemeBuilder,
+    this.cupertinoThemeBuilder = defaultCupertinoThemeBuilder,
+    this.materialThemeBuilder = defaultMaterialThemeBuilder,
   })  : routeInformationProvider = null,
         routeInformationParser = null,
         routerDelegate = null,
@@ -260,8 +291,8 @@ class ShadApp extends StatefulWidget {
     this.restorationScopeId,
     this.scrollBehavior = const CupertinoScrollBehavior(),
     this.themeCurve = Curves.linear,
-    this.cupertinoThemeBuilder,
-    this.materialThemeBuilder,
+    this.cupertinoThemeBuilder = defaultCupertinoThemeBuilder,
+    this.materialThemeBuilder = defaultMaterialThemeBuilder,
   })  : navigatorObservers = null,
         navigatorKey = null,
         onGenerateRoute = null,
@@ -285,7 +316,7 @@ class ShadApp extends StatefulWidget {
         backButtonDispatcher = null,
         builder = null,
         color = null,
-        cupertinoThemeBuilder = null,
+        cupertinoThemeBuilder = defaultCupertinoThemeBuilder,
         debugShowCheckedModeBanner = true,
         home = null,
         initialRoute = null,
@@ -293,7 +324,7 @@ class ShadApp extends StatefulWidget {
         localeListResolutionCallback = null,
         localeResolutionCallback = null,
         localizationsDelegates = null,
-        materialThemeBuilder = null,
+        materialThemeBuilder = defaultMaterialThemeBuilder,
         navigatorKey = null,
         navigatorObservers = null,
         onGenerateInitialRoutes = null,
@@ -315,6 +346,70 @@ class ShadApp extends StatefulWidget {
         themeCurve = Curves.linear,
         title = '',
         type = ShadAppType.custom;
+
+  static ThemeData defaultMaterialThemeBuilder(
+    BuildContext context,
+    ShadThemeData themeData,
+    String fontFamily,
+    Iterable<ThemeExtension<dynamic>>? extensions,
+    Brightness brightness,
+    Color primaryColor,
+    Color onPrimaryColor,
+    Color secondaryColor,
+    Color onSecondaryColor,
+    Color errorColor,
+    Color onErrorColor,
+    Color backgroundColor,
+    Color onBackgroundColor,
+    Color surfaceColor,
+    Color onSurfaceColor,
+    Color scaffoldBackgroundColor,
+    DividerThemeData dividerTheme,
+    TextSelectionThemeData textSelectionTheme,
+  ) {
+    return ThemeData(
+      fontFamily: fontFamily,
+      extensions: extensions,
+      colorScheme: ColorScheme(
+        brightness: brightness,
+        primary: primaryColor,
+        onPrimary: onPrimaryColor,
+        secondary: secondaryColor,
+        onSecondary: onSecondaryColor,
+        error: errorColor,
+        onError: onErrorColor,
+        // Keep deprecated members for backwards compatibility
+        // ignore: deprecated_member_use
+        background: backgroundColor,
+        // ignore: deprecated_member_use
+        onBackground: onBackgroundColor,
+        surface: surfaceColor,
+        onSurface: onSurfaceColor,
+      ),
+      scaffoldBackgroundColor: scaffoldBackgroundColor,
+      brightness: brightness,
+      dividerTheme: dividerTheme,
+      textSelectionTheme: textSelectionTheme,
+    );
+  }
+
+  static CupertinoThemeData defaultCupertinoThemeBuilder(
+    BuildContext context,
+    ShadThemeData themeData,
+    Brightness brightness,
+    Color primaryColor,
+    Color primaryContrastingColor,
+    Color scaffoldBackgroundColor,
+    Color barBackgroundColor,
+  ) {
+    return CupertinoThemeData(
+      primaryColor: primaryColor,
+      primaryContrastingColor: primaryContrastingColor,
+      scaffoldBackgroundColor: scaffoldBackgroundColor,
+      barBackgroundColor: barBackgroundColor,
+      brightness: brightness,
+    );
+  }
 
   /// The type of app to use.
   ///
@@ -569,13 +664,9 @@ class ShadApp extends StatefulWidget {
   /// A custom app widget builder.
   final Widget Function(BuildContext context, ThemeData theme)? appBuilder;
 
-  final ThemeData Function(BuildContext context, ThemeData theme)?
-      materialThemeBuilder;
+  final MaterialThemeBuilder materialThemeBuilder;
 
-  final CupertinoThemeData Function(
-    BuildContext context,
-    CupertinoThemeData theme,
-  )? cupertinoThemeBuilder;
+  final CupertinoThemeBuilder cupertinoThemeBuilder;
 
   @override
   State<ShadApp> createState() => _ShadAppState();
@@ -659,62 +750,51 @@ class _ShadAppState extends State<ShadApp> {
 
   ThemeData materialTheme(BuildContext context) {
     final themeData = theme(context);
-    var mTheme = ThemeData(
-      fontFamily: themeData.textTheme.family,
-      extensions: themeData.extensions,
-      colorScheme: ColorScheme(
-        brightness: themeData.brightness,
-        primary: themeData.colorScheme.primary,
-        onPrimary: themeData.colorScheme.primaryForeground,
-        secondary: themeData.colorScheme.secondary,
-        onSecondary: themeData.colorScheme.secondaryForeground,
-        error: themeData.colorScheme.destructive,
-        onError: themeData.colorScheme.destructiveForeground,
-        // Keep deprecated members for backwards compatibility
-        // ignore: deprecated_member_use
-        background: themeData.colorScheme.background,
-        // ignore: deprecated_member_use
-        onBackground: themeData.colorScheme.foreground,
-        surface: themeData.colorScheme.card,
-        onSurface: themeData.colorScheme.cardForeground,
-      ),
-      scaffoldBackgroundColor: themeData.colorScheme.background,
-      brightness: themeData.brightness,
-      dividerTheme: DividerThemeData(
+
+    final mTheme = widget.materialThemeBuilder(
+      context,
+      themeData,
+      themeData.textTheme.family,
+      themeData.extensions,
+      themeData.brightness,
+      themeData.colorScheme.primary,
+      themeData.colorScheme.primaryForeground,
+      themeData.colorScheme.secondary,
+      themeData.colorScheme.secondaryForeground,
+      themeData.colorScheme.destructive,
+      themeData.colorScheme.destructiveForeground,
+      themeData.colorScheme.background,
+      themeData.colorScheme.foreground,
+      themeData.colorScheme.card,
+      themeData.colorScheme.cardForeground,
+      themeData.colorScheme.background,
+      DividerThemeData(
         color: themeData.colorScheme.border,
         thickness: 1,
       ),
-      textSelectionTheme: TextSelectionThemeData(
+      TextSelectionThemeData(
         cursorColor: themeData.colorScheme.primary,
         selectionColor: themeData.colorScheme.selection,
         selectionHandleColor: themeData.colorScheme.primary,
       ),
     );
-    mTheme = mTheme.copyWith(
+    return mTheme.copyWith(
       textTheme:
-          themeData.textTheme.materialTextTheme(textTheme: mTheme.textTheme),
+          themeData.textTheme.applyGoogleFontToTextTheme(mTheme.textTheme),
     );
-
-    if (widget.materialThemeBuilder == null) {
-      return mTheme;
-    }
-    return widget.materialThemeBuilder!(context, mTheme);
   }
 
   CupertinoThemeData cupertinoTheme(BuildContext context) {
     final themeData = theme(context);
-    final cTheme = CupertinoThemeData(
-      primaryColor: themeData.colorScheme.primary,
-      primaryContrastingColor: themeData.colorScheme.primaryForeground,
-      scaffoldBackgroundColor: themeData.colorScheme.background,
-      barBackgroundColor: themeData.colorScheme.primary,
-      brightness: themeData.brightness,
+    return widget.cupertinoThemeBuilder(
+      context,
+      themeData,
+      themeData.brightness,
+      themeData.colorScheme.primary,
+      themeData.colorScheme.primaryForeground,
+      themeData.colorScheme.background,
+      themeData.colorScheme.background,
     );
-
-    if (widget.cupertinoThemeBuilder == null) {
-      return cTheme;
-    }
-    return widget.cupertinoThemeBuilder!(context, cTheme);
   }
 
   Widget _builder(BuildContext context, Widget? child) {

--- a/lib/src/theme/text_theme/theme.dart
+++ b/lib/src/theme/text_theme/theme.dart
@@ -305,97 +305,81 @@ class ShadTextTheme {
     );
   }
 
-  TextTheme materialTextTheme({TextTheme? textTheme}) {
-    final effectiveTextTheme = textTheme ?? const TextTheme();
-    if (googleFontBuilder == null) return effectiveTextTheme;
+  TextTheme applyGoogleFontToTextTheme(TextTheme textTheme) {
+    if (googleFontBuilder == null) return textTheme;
     return TextTheme(
       displayLarge: GoogleFontTextStyle(
-        (effectiveTextTheme.displayLarge ?? const TextStyle())
-            .omitFamilyAndPackage,
+        (textTheme.displayLarge ?? const TextStyle()).omitFamilyAndPackage,
         builder: googleFontBuilder!,
         overrideFamilyWithBuilder: true,
       ),
       displayMedium: GoogleFontTextStyle(
-        (effectiveTextTheme.displayMedium ?? const TextStyle())
-            .omitFamilyAndPackage,
+        (textTheme.displayMedium ?? const TextStyle()).omitFamilyAndPackage,
         builder: googleFontBuilder!,
         overrideFamilyWithBuilder: true,
       ),
       displaySmall: GoogleFontTextStyle(
-        (effectiveTextTheme.displaySmall ?? const TextStyle())
-            .omitFamilyAndPackage,
+        (textTheme.displaySmall ?? const TextStyle()).omitFamilyAndPackage,
         builder: googleFontBuilder!,
         overrideFamilyWithBuilder: true,
       ),
       headlineLarge: GoogleFontTextStyle(
-        (effectiveTextTheme.headlineLarge ?? const TextStyle())
-            .omitFamilyAndPackage,
+        (textTheme.headlineLarge ?? const TextStyle()).omitFamilyAndPackage,
         builder: googleFontBuilder!,
         overrideFamilyWithBuilder: true,
       ),
       headlineMedium: GoogleFontTextStyle(
-        (effectiveTextTheme.headlineMedium ?? const TextStyle())
-            .omitFamilyAndPackage,
+        (textTheme.headlineMedium ?? const TextStyle()).omitFamilyAndPackage,
         builder: googleFontBuilder!,
         overrideFamilyWithBuilder: true,
       ),
       headlineSmall: GoogleFontTextStyle(
-        (effectiveTextTheme.headlineSmall ?? const TextStyle())
-            .omitFamilyAndPackage,
+        (textTheme.headlineSmall ?? const TextStyle()).omitFamilyAndPackage,
         builder: googleFontBuilder!,
         overrideFamilyWithBuilder: true,
       ),
       titleLarge: GoogleFontTextStyle(
-        (effectiveTextTheme.titleLarge ?? const TextStyle())
-            .omitFamilyAndPackage,
+        (textTheme.titleLarge ?? const TextStyle()).omitFamilyAndPackage,
         builder: googleFontBuilder!,
         overrideFamilyWithBuilder: true,
       ),
       titleMedium: GoogleFontTextStyle(
-        (effectiveTextTheme.titleMedium ?? const TextStyle())
-            .omitFamilyAndPackage,
+        (textTheme.titleMedium ?? const TextStyle()).omitFamilyAndPackage,
         builder: googleFontBuilder!,
         overrideFamilyWithBuilder: true,
       ),
       titleSmall: GoogleFontTextStyle(
-        (effectiveTextTheme.titleSmall ?? const TextStyle())
-            .omitFamilyAndPackage,
+        (textTheme.titleSmall ?? const TextStyle()).omitFamilyAndPackage,
         builder: googleFontBuilder!,
         overrideFamilyWithBuilder: true,
       ),
       bodyLarge: GoogleFontTextStyle(
-        (effectiveTextTheme.bodyLarge ?? const TextStyle())
-            .omitFamilyAndPackage,
+        (textTheme.bodyLarge ?? const TextStyle()).omitFamilyAndPackage,
         builder: googleFontBuilder!,
         overrideFamilyWithBuilder: true,
       ),
       bodyMedium: GoogleFontTextStyle(
-        (effectiveTextTheme.bodyMedium ?? const TextStyle())
-            .omitFamilyAndPackage,
+        (textTheme.bodyMedium ?? const TextStyle()).omitFamilyAndPackage,
         builder: googleFontBuilder!,
         overrideFamilyWithBuilder: true,
       ),
       bodySmall: GoogleFontTextStyle(
-        (effectiveTextTheme.bodySmall ?? const TextStyle())
-            .omitFamilyAndPackage,
+        (textTheme.bodySmall ?? const TextStyle()).omitFamilyAndPackage,
         builder: googleFontBuilder!,
         overrideFamilyWithBuilder: true,
       ),
       labelLarge: GoogleFontTextStyle(
-        (effectiveTextTheme.labelLarge ?? const TextStyle())
-            .omitFamilyAndPackage,
+        (textTheme.labelLarge ?? const TextStyle()).omitFamilyAndPackage,
         builder: googleFontBuilder!,
         overrideFamilyWithBuilder: true,
       ),
       labelMedium: GoogleFontTextStyle(
-        (effectiveTextTheme.labelMedium ?? const TextStyle())
-            .omitFamilyAndPackage,
+        (textTheme.labelMedium ?? const TextStyle()).omitFamilyAndPackage,
         builder: googleFontBuilder!,
         overrideFamilyWithBuilder: true,
       ),
       labelSmall: GoogleFontTextStyle(
-        (effectiveTextTheme.labelSmall ?? const TextStyle())
-            .omitFamilyAndPackage,
+        (textTheme.labelSmall ?? const TextStyle()).omitFamilyAndPackage,
         builder: googleFontBuilder!,
         overrideFamilyWithBuilder: true,
       ),


### PR DESCRIPTION
# Part 1

Right now customizing the material theme based off of the shadcn theme is burden some.
1. Some of the material theme is customized using the shadcn theme and there is no way to know what unless you read the source code.
2. You don't have access to the final shad theme in the builder, ShadTheme.of(context) throws a null error

Instead of guessing, why not include the variable make the api more explicit.

### Before
```
materialThemeBuilder: (context, theme) {
  return theme.copyWith(
      // Guess what you can't replace
    );
  },
``` 

### After
```dart
materialThemeBuilder: ( 
  context,
  themeData,
  fontFamily,
   extensions,
  brightness,
  primaryColor,
  onPrimaryColor,
  secondaryColor,
  onSecondaryColor,
  errorColor,
  onErrorColor,
  backgroundColor,
  onBackgroundColor,
  surfaceColor,
  onSurfaceColor,
  scaffoldBackgroundColor,
  dividerTheme,
  textSelectionTheme,
) {
    return ThemeData(
      /// You now know what you're doing
    );
  },
```

What great about this, is that if you ever wanted to make the material theme more customized, you just add another parameter (e.g. tooltipTheme) and it will be a breaking release, instead of people wondering why their app compiles but things have changed.

---

### Part 2

`materialTextTheme` was a lie, renamed it to `applyGoogleFontToTextTheme`


@nank1ro What are your thoughts?