### PR TITLE
Add Theme Color Selector for Dynamic Component Previews in Docs

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -7,6 +7,10 @@ export default defineConfig({
   integrations: [
     starlight({
       title: 'Flutter Shadcn UI docs',
+      components: {
+        LanguageSelect: './src/components/SelectColor.astro',
+
+      },
       social: {
         github: 'https://github.com/nank1ro',
         twitter: 'https://twitter.com/nank1ro'
@@ -19,6 +23,7 @@ export default defineConfig({
         }
       }],
       sidebar: [
+       
         {
           label: 'mariuti.com',
           link: 'https://mariuti.com',
@@ -75,7 +80,7 @@ export default defineConfig({
           ],
 
         }
-      ],
+      ], 
     }),
   ],
   site: 'https://flutter-shadcn-ui.mariuti.com',

--- a/docs/src/components/Preview.astro
+++ b/docs/src/components/Preview.astro
@@ -11,10 +11,10 @@ let uuid = crypto.randomUUID();
 // const defaultPrefix = "http://localhost:12345/"; 
 
 // Default prefix for flutter playground site hosted by the author.
-const defaultPrefix = "https://shadcn-ui-playground.pages.dev/"; // build and deploy the flutter playground web app to see changes
+// const defaultPrefix = "https://shadcn-ui-playground.pages.dev/"; 
 
 // Default prefix for flutter playground site hosted by the contributor (Harkirat Singh).
-// const defaultPrefix = "https://flutter-shadcn-playground.web.app/" 
+const defaultPrefix = "https://flutter-shadcn-playground.web.app/" 
 ---
 
 <Tabs>

--- a/docs/src/components/Preview.astro
+++ b/docs/src/components/Preview.astro
@@ -7,9 +7,14 @@ interface Props {
 const { src, minHeight = "200px" } = Astro.props;
 import { Tabs, TabItem } from "@astrojs/starlight/components";
 let uuid = crypto.randomUUID();
-// const defaultPrefix = "http://localhost:12345/"; // Default prefix for flutter playground site on localmachine
+// Default prefix for flutter playground site on localmachine
+// const defaultPrefix = "http://localhost:12345/"; 
 
-const defaultPrefix = "https://shadcn-ui-playground.pages.dev/"; // Default prefix for flutter playground site hosted.
+// Default prefix for flutter playground site hosted by the author.
+// const defaultPrefix = "https://shadcn-ui-playground.pages.dev/"; 
+
+// Default prefix for flutter playground site hosted by the contributor (Harkirat Singh).
+const defaultPrefix = "https://flutter-shadcn-playground.web.app/" 
 ---
 
 <Tabs>

--- a/docs/src/components/Preview.astro
+++ b/docs/src/components/Preview.astro
@@ -7,9 +7,9 @@ interface Props {
 const { src, minHeight = "200px" } = Astro.props;
 import { Tabs, TabItem } from "@astrojs/starlight/components";
 let uuid = crypto.randomUUID();
-const defaultPrefix = "http://localhost:12345/"; // Default prefix for flutter playground site on localmachine
+// const defaultPrefix = "http://localhost:12345/"; // Default prefix for flutter playground site on localmachine
 
-// const defaultPrefix = "https://shadcn-ui-playground.pages.dev/"; // Default prefix for flutter playground site hosted.
+const defaultPrefix = "https://shadcn-ui-playground.pages.dev/"; // Default prefix for flutter playground site hosted.
 ---
 
 <Tabs>

--- a/docs/src/components/Preview.astro
+++ b/docs/src/components/Preview.astro
@@ -7,6 +7,9 @@ interface Props {
 const { src, minHeight = "200px" } = Astro.props;
 import { Tabs, TabItem } from "@astrojs/starlight/components";
 let uuid = crypto.randomUUID();
+const defaultPrefix = "http://localhost:12345/"; // Default prefix for flutter playground site on localmachine
+
+// const defaultPrefix = "https://shadcn-ui-playground.pages.dev/"; // Default prefix for flutter playground site hosted.
 ---
 
 <Tabs>
@@ -14,43 +17,78 @@ let uuid = crypto.randomUUID();
         <iframe
             id={uuid}
             class="preview"
-            style=`border: 1px solid rgba(0, 0, 0, 0.1); min-height: ${minHeight}; width: 100%;`
-            loading="lazy"></iframe>
+            style={`border: 1px solid rgba(0, 0, 0, 0.1); min-height: ${minHeight}; width: 100%;`}
+            loading="lazy"
+        ></iframe>
     </TabItem>
     <TabItem label="Code">
         <slot />
     </TabItem>
 </Tabs>
 
-<script is:inline define:vars={{ uuid, src }}>
+<script define:vars={{defaultPrefix, uuid, src }}>
+    const fullSrc = `${defaultPrefix}${src}`; // Combine prefix and prop src
+    // Utility function to update query string parameters
     function updateQueryStringParameter(uri, key, value) {
-        var re = new RegExp("([?&])" + key + "=.*?(&|$)", "i");
-        var separator = uri.indexOf("?") !== -1 ? "&" : "?";
+        const re = new RegExp("([?&])" + key + "=.*?(&|$)", "i");
+        const separator = uri.includes("?") ? "&" : "?";
         if (uri.match(re)) {
-            return uri.replace(re, "$1" + key + "=" + value + "$2");
+            return uri.replace(re, `$1${key}=${value}$2`);
         } else {
-            return uri + separator + key + "=" + value;
+            return `${uri}${separator}${key}=${value}`;
         }
     }
 
-    function updateSrcForTheme() {
-        const isThemeDark =
-            document.documentElement.attributes["data-theme"].value == "dark";
+    // Function to update iframe src for both theme and theme color
+    function updateIframeSrc() {
         const iframe = document.getElementById(uuid);
-        const iframeSrc = iframe.getAttribute("src") ?? "";
-        const withoutSrc = iframeSrc === "";
-        const iframeTheme = iframeSrc.includes("theme=dark") ? "dark" : "light";
-        if (isThemeDark && (withoutSrc || iframeTheme != "dark")) {
-            iframe.src = updateQueryStringParameter(src, "theme", "dark");
-        } else if (!isThemeDark && (withoutSrc || iframeTheme != "light")) {
-            iframe.src = updateQueryStringParameter(src, "theme", "light");
+        if (!iframe) return;
+
+        const themeMode = document.documentElement.getAttribute("data-theme");
+        const themeColor = document.documentElement.getAttribute("data-theme-color");
+
+        let iframeSrc = iframe.getAttribute("src") || fullSrc;
+
+        if (themeMode) {
+            iframeSrc = updateQueryStringParameter(iframeSrc, "theme", themeMode);
         }
+
+        if (themeColor) {
+            iframeSrc = updateQueryStringParameter(iframeSrc, "themeColor", themeColor);
+        }
+
+        iframe.src = iframeSrc;
+        console.log(`Updated iframe src: ${iframe.src}`);
     }
 
-    // Watch the document element
-    const observer = new MutationObserver(updateSrcForTheme);
+    // Observer callback for theme mode changes
+    function updateSrcForTheme() {
+        updateIframeSrc();
+    }
+
+    // Observer callback for theme color changes
+    function updateSrcForThemeColor() {
+        updateIframeSrc();
+    }
+
+    // Initialize iframe on page load
+    document.addEventListener("DOMContentLoaded", () => {
+        updateIframeSrc();
+    });
+
+    // Observe changes to the `data-theme` and `data-theme-color` attributes
+    const observer = new MutationObserver((mutations) => {
+        mutations.forEach((mutation) => {
+            if (mutation.attributeName === "data-theme") {
+                updateSrcForTheme();
+            } else if (mutation.attributeName === "data-theme-color") {
+                updateSrcForThemeColor();
+            }
+        });
+    });
+
     observer.observe(document.documentElement, {
         attributes: true,
-        attributeFilter: ["data-theme"],
+        attributeFilter: ["data-theme", "data-theme-color"],
     });
 </script>

--- a/docs/src/components/Preview.astro
+++ b/docs/src/components/Preview.astro
@@ -11,10 +11,10 @@ let uuid = crypto.randomUUID();
 // const defaultPrefix = "http://localhost:12345/"; 
 
 // Default prefix for flutter playground site hosted by the author.
-// const defaultPrefix = "https://shadcn-ui-playground.pages.dev/"; 
+const defaultPrefix = "https://shadcn-ui-playground.pages.dev/"; // build and deploy the flutter playground web app to see changes
 
 // Default prefix for flutter playground site hosted by the contributor (Harkirat Singh).
-const defaultPrefix = "https://flutter-shadcn-playground.web.app/" 
+// const defaultPrefix = "https://flutter-shadcn-playground.web.app/" 
 ---
 
 <Tabs>

--- a/docs/src/components/SelectColor.astro
+++ b/docs/src/components/SelectColor.astro
@@ -2,6 +2,7 @@
 ---
 
 <select id="selectColor" class="theme-color-select" >
+    <option disabled selected>Theme Color</option>
     <option value="blue">Blue</option>
     <option value="gray">Gray</option>
     <option value="green">Green</option>

--- a/docs/src/components/SelectColor.astro
+++ b/docs/src/components/SelectColor.astro
@@ -1,0 +1,57 @@
+---
+---
+
+<select id="selectColor" class="theme-color-select" >
+    <option value="blue">Blue</option>
+    <option value="gray">Gray</option>
+    <option value="green">Green</option>
+    <option value="neutral">Neutral</option>
+    <option value="orange">Orange</option>
+    <option value="red">Red</option>
+    <option value="rose">Rose</option>
+    <option value="slate">Slate</option>
+    <option value="stone">Stone</option>
+    <option value="violet">Violet</option>
+    <option value="yellow">Yellow</option>
+    <option value="zinc">Zinc</option>
+</select>
+
+<script is:inline>
+    document.addEventListener("DOMContentLoaded", () => {
+        const selectColorElement = document.getElementById("selectColor");
+        const localStorageKey = "selectedThemeColor";
+
+        // Save the selected color to localStorage and update the document attribute
+        const saveColorToLocalStorage = (color) => {
+            document.documentElement.setAttribute("data-theme-color", color);
+            localStorage.setItem(localStorageKey, color);
+        };
+
+        // Initialize the dropdown with the saved color
+        const initializeColorPicker = () => {
+            const savedColor = localStorage.getItem(localStorageKey);
+            if (savedColor) {
+                selectColorElement.value = savedColor;
+                document.documentElement.setAttribute("data-theme-color", savedColor);
+            }
+        };
+
+        // Save color when user selects a new option
+        selectColorElement.addEventListener("change", (event) => {
+            const selectedColor = event.target.value;
+            saveColorToLocalStorage(selectedColor);
+        });
+
+        initializeColorPicker();
+    });
+</script>
+
+
+<style>
+    .theme-color-select {
+      padding: 0.5rem;
+      
+      font-size: 1rem;
+      margin: 1rem 0;
+    }
+</style>

--- a/docs/src/content/docs/Components/accordion.mdx
+++ b/docs/src/content/docs/Components/accordion.mdx
@@ -7,7 +7,7 @@ import Preview from '../../../components/Preview.astro';
 
 A vertically stacked set of interactive headings that each reveal a section of content.
 
-<Preview src="https://shadcn-ui-playground.pages.dev/accordion?style=single" minHeight="500px">
+<Preview src="accordion?style=single" minHeight="500px">
 
 ```dart
 final details = [
@@ -45,7 +45,7 @@ Widget build(BuildContext context) {
 
 ## Multiple
 
-<Preview src="https://shadcn-ui-playground.pages.dev/accordion?style=multiple" minHeight="500px">
+<Preview src="accordion?style=multiple" minHeight="500px">
 
 ```dart
 final details = [

--- a/docs/src/content/docs/Components/alert.mdx
+++ b/docs/src/content/docs/Components/alert.mdx
@@ -8,9 +8,8 @@ import Preview from "../../../components/Preview.astro";
 
 Displays a callout for user attention.
 
-<Preview src="https://shadcn-ui-playground.pages.dev/alert?style=primary">
-
-```dart
+<Preview src="alert?style=primary">
+ ```dart
 ShadAlert(
   iconData: LucideIcons.terminal,
   title: Text('Heads up!'),
@@ -23,9 +22,8 @@ ShadAlert(
 
 ## Destructive
 
-<Preview src="https://shadcn-ui-playground.pages.dev/alert?style=destructive">
-
-```dart
+<Preview src="alert?style=destructive">
+ ```dart
 ShadAlert.destructive(
   iconData: LucideIcons.circleAlert,
   title: Text('Error'),

--- a/docs/src/content/docs/Components/avatar.mdx
+++ b/docs/src/content/docs/Components/avatar.mdx
@@ -7,7 +7,7 @@ import Preview from '../../../components/Preview.astro';
 
 An image element with a placeholder for representing the user.
 
-<Preview src="https://shadcn-ui-playground.pages.dev/avatar">
+<Preview src="avatar">
  ```dart
 ShadAvatar(
   'https://app.requestly.io/delay/2000/avatars.githubusercontent.com/u/124599?v=4',

--- a/docs/src/content/docs/Components/badge.mdx
+++ b/docs/src/content/docs/Components/badge.mdx
@@ -9,7 +9,7 @@ Displays a badge or a component that looks like a badge.
 
 ## Primary
 
-<Preview src="https://shadcn-ui-playground.pages.dev/badge?style=primary">
+<Preview src="badge?style=primary">
  ```dart
 ShadBadge(
   child: const Text('Primary'),
@@ -19,7 +19,7 @@ ShadBadge(
 
 ## Secondary
 
-<Preview src="https://shadcn-ui-playground.pages.dev/badge?style=secondary">
+<Preview src="badge?style=secondary">
 ```dart
 ShadBadge.secondary(
   child: const Text('Secondary'),
@@ -29,7 +29,7 @@ ShadBadge.secondary(
 
 ## Destructive
 
-<Preview src="https://shadcn-ui-playground.pages.dev/badge?style=destructive">
+<Preview src="badge?style=destructive">
 ```dart
 ShadBadge.destructive(
   child: const Text('Destructive'),
@@ -39,7 +39,7 @@ ShadBadge.destructive(
 
 ## Outline
 
-<Preview src="https://shadcn-ui-playground.pages.dev/badge?style=outline">
+<Preview src="badge?style=outline">
 ```dart
 ShadBadge.outline(
   child: const Text('Outline'),

--- a/docs/src/content/docs/Components/button.mdx
+++ b/docs/src/content/docs/Components/button.mdx
@@ -6,11 +6,13 @@ sidebar:
 
 import Preview from "../../../components/Preview.astro";
 
+
 Displays a button or a component that looks like a button.
+
 
 ## Primary
 
-<Preview src="https://shadcn-ui-playground.pages.dev/button?style=primary">
+<Preview src="button?style=primary">
 
 ```dart
 ShadButton(
@@ -23,7 +25,7 @@ ShadButton(
 
 ## Secondary
 
-<Preview src="https://shadcn-ui-playground.pages.dev/button?style=secondary">
+<Preview src="button?style=secondary">
 
 ```dart
 ShadButton.secondary(
@@ -36,7 +38,7 @@ ShadButton.secondary(
 
 ## Destructive
 
-<Preview src="https://shadcn-ui-playground.pages.dev/button?style=destructive">
+<Preview src="button?style=destructive">
 
 ```dart
 ShadButton.destructive(
@@ -49,7 +51,7 @@ ShadButton.destructive(
 
 ## Outline
 
-<Preview src="https://shadcn-ui-playground.pages.dev/button?style=outline">
+<Preview src="button?style=outline">
 
 ```dart
 ShadButton.outline(
@@ -62,7 +64,7 @@ ShadButton.outline(
 
 ## Ghost
 
-<Preview src="https://shadcn-ui-playground.pages.dev/button?style=ghost">
+<Preview src="button?style=ghost">
 
 ```dart
 ShadButton.ghost(
@@ -75,7 +77,7 @@ ShadButton.ghost(
 
 ## Link
 
-<Preview src="https://shadcn-ui-playground.pages.dev/button?style=link">
+<Preview src="button?style=link">
 
 ```dart
 ShadButton.link(
@@ -88,7 +90,7 @@ ShadButton.link(
 
 ## Icon
 
-<Preview src="https://shadcn-ui-playground.pages.dev/button?style=icon">
+<Preview src="button?style=icon">
 
 ```dart
 ShadButton.outline(
@@ -101,7 +103,7 @@ ShadButton.outline(
 
 ## Text and Icon
 
-<Preview src="https://shadcn-ui-playground.pages.dev/button?style=textIcon">
+<Preview src="button?style=textIcon">
 
 ```dart
 ShadButton(
@@ -115,7 +117,7 @@ ShadButton(
 
 ## Loading
 
-<Preview src="https://shadcn-ui-playground.pages.dev/button?style=loading">
+<Preview src="button?style=loading">
 
 ```dart
 ShadButton(
@@ -135,7 +137,7 @@ ShadButton(
 
 ## Gradient and Shadow
 
-<Preview src="https://shadcn-ui-playground.pages.dev/button?style=gradientShadow">
+<Preview src="button?style=gradientShadow">
 
 ```dart
 ShadButton(

--- a/docs/src/content/docs/Components/calendar.mdx
+++ b/docs/src/content/docs/Components/calendar.mdx
@@ -8,7 +8,7 @@ import Preview from "../../../components/Preview.astro";
 
 A date field component that allows users to enter and edit date.
 
-<Preview src="https://shadcn-ui-playground.pages.dev/calendar?style=single" minHeight="450px">
+<Preview src="calendar?style=single" minHeight="450px">
 
 ```dart
 class SingleCalendar extends StatefulWidget {
@@ -36,7 +36,7 @@ class _SingleCalendarState extends State<SingleCalendar> {
 
 ## Multiple
 
-<Preview src="https://shadcn-ui-playground.pages.dev/calendar?style=multiple" minHeight="450px">
+<Preview src="calendar?style=multiple" minHeight="450px">
 
 ```dart
 class MultipleCalendar extends StatefulWidget {
@@ -66,7 +66,7 @@ class _MultipleCalendarState extends State<MultipleCalendar> {
 
 ## Range
 
-<Preview src="https://shadcn-ui-playground.pages.dev/calendar?style=range" minHeight="450px">
+<Preview src="calendar?style=range" minHeight="450px">
 
 ```dart
 class RangeCalendar extends StatelessWidget {
@@ -91,55 +91,55 @@ class RangeCalendar extends StatelessWidget {
 #### Dropdown
 
 <Preview
-  src="https://shadcn-ui-playground.pages.dev/calendar?captionLayout=dropdown"
+  src="calendar?captionLayout=dropdown"
   minHeight="500px"
 />
 
 #### DropdownMonths
 
 <Preview
-  src="https://shadcn-ui-playground.pages.dev/calendar?captionLayout=dropdownMonths"
+  src="calendar?captionLayout=dropdownMonths"
   minHeight="500px"
 />
 
 #### DropdownYears
 
 <Preview
-  src="https://shadcn-ui-playground.pages.dev/calendar?captionLayout=dropdownYears"
+  src="calendar?captionLayout=dropdownYears"
   minHeight="450px"
 />
 
 ### Hide Navigation
 
 <Preview
-  src="https://shadcn-ui-playground.pages.dev/calendar?hideNavigation"
+  src="calendar?hideNavigation"
   minHeight="450px"
 />
 
 ### Show Week Numbers
 
 <Preview
-  src="https://shadcn-ui-playground.pages.dev/calendar?showWeekNumbers"
+  src="calendar?showWeekNumbers"
   minHeight="450px"
 />
 
 ### Show Outside Days (false)
 
 <Preview
-  src="https://shadcn-ui-playground.pages.dev/calendar?showOutsideDays=0"
+  src="calendar?showOutsideDays=0"
   minHeight="450px"
 />
 
 ### Fixed Weeks
 
 <Preview
-  src="https://shadcn-ui-playground.pages.dev/calendar?fixedWeeks"
+  src="calendar?fixedWeeks"
   minHeight="450px"
 />
 
 ### Hide Weekday Names
 
 <Preview
-  src="https://shadcn-ui-playground.pages.dev/calendar?hideWeekdayNames"
+  src="calendar?hideWeekdayNames"
   minHeight="450px"
 />

--- a/docs/src/content/docs/Components/card.mdx
+++ b/docs/src/content/docs/Components/card.mdx
@@ -8,7 +8,7 @@ import Preview from "../../../components/Preview.astro";
 
 Displays a card with header, content, and footer.
 
-<Preview src="https://shadcn-ui-playground.pages.dev/card" minHeight="500px">
+<Preview src="card" minHeight="500px">
 
 ```dart
 const frameworks = {
@@ -73,7 +73,7 @@ class CardProject extends StatelessWidget {
 
 ## Notifications Example
 
-<Preview src="https://shadcn-ui-playground.pages.dev/card?style=notifications"  minHeight="500px">
+<Preview src="card?style=notifications"  minHeight="500px">
 
 ```dart
 import 'package:awesome_flutter_extensions/awesome_flutter_extensions.dart';

--- a/docs/src/content/docs/Components/checkbox.mdx
+++ b/docs/src/content/docs/Components/checkbox.mdx
@@ -8,7 +8,7 @@ import Preview from "../../../components/Preview.astro";
 
 A control that allows the user to toggle between checked and not checked.
 
-<Preview src="https://shadcn-ui-playground.pages.dev/checkbox">
+<Preview src="checkbox">
 
 ```dart
 class CheckboxSample extends StatefulWidget {
@@ -39,7 +39,7 @@ class _CheckboxSampleState extends State<CheckboxSample> {
 
 ## Form
 
-<Preview src="https://shadcn-ui-playground.pages.dev/form?style=checkboxField" minHeight="300px">
+<Preview src="form?style=checkboxField" minHeight="300px">
 
 ```dart
 ShadCheckboxFormField(

--- a/docs/src/content/docs/Components/context-menu.mdx
+++ b/docs/src/content/docs/Components/context-menu.mdx
@@ -8,7 +8,7 @@ import Preview from "../../../components/Preview.astro";
 
 Displays a menu to the user — such as a set of actions or functions — triggered by a mouse right-click.
 
-<Preview src="https://shadcn-ui-playground.pages.dev/context-menu" minHeight="600px">
+<Preview src="context-menu" minHeight="600px">
 
 ```dart
 import 'package:flutter/material.dart';

--- a/docs/src/content/docs/Components/date-picker.mdx
+++ b/docs/src/content/docs/Components/date-picker.mdx
@@ -8,7 +8,7 @@ import Preview from "../../../components/Preview.astro";
 
 A date picker component with range and presets.
 
-<Preview src="https://shadcn-ui-playground.pages.dev/date-picker?style=single" minHeight="450px">
+<Preview src="date-picker?style=single" minHeight="450px">
 
 ```dart
 class SingleDatePicker extends StatelessWidget {
@@ -28,7 +28,7 @@ class SingleDatePicker extends StatelessWidget {
 
 ## Date Range Picker
 
-<Preview src="https://shadcn-ui-playground.pages.dev/date-picker?style=range" minHeight="450px">
+<Preview src="date-picker?style=range" minHeight="450px">
 
 ```dart
 class RangeDatePicker extends StatelessWidget {
@@ -48,7 +48,7 @@ class RangeDatePicker extends StatelessWidget {
 
 ## With Presets
 
-<Preview src="https://shadcn-ui-playground.pages.dev/date-picker?style=presets" minHeight="550px">
+<Preview src="date-picker?style=presets" minHeight="550px">
 
 ```dart
 const presets = {
@@ -109,7 +109,7 @@ class _PresetsDatePickerState extends State<PresetsDatePicker> {
 
 ## Form
 
-<Preview src="https://shadcn-ui-playground.pages.dev/form?style=datePickerField" minHeight="700px">
+<Preview src="form?style=datePickerField" minHeight="700px">
 
 ```dart
 ShadDatePickerFormField(
@@ -130,7 +130,7 @@ ShadDatePickerFormField(
 
 ## DateRangePickerFormField
 
-<Preview src="https://shadcn-ui-playground.pages.dev/form?style=dateRangePickerField" minHeight="700px">
+<Preview src="form?style=dateRangePickerField" minHeight="700px">
 
 ```dart
 ShadDateRangePickerFormField(

--- a/docs/src/content/docs/Components/dialog.mdx
+++ b/docs/src/content/docs/Components/dialog.mdx
@@ -8,7 +8,7 @@ import Preview from "../../../components/Preview.astro";
 
 A modal dialog that interrupts the user.
 
-<Preview src="https://shadcn-ui-playground.pages.dev/dialog?style=primary" minHeight="500px">
+<Preview src="dialog?style=primary" minHeight="500px">
 
 ```dart
 final profile = [
@@ -72,7 +72,7 @@ class DialogExample extends StatelessWidget {
 
 ## Alert
 
-<Preview src="https://shadcn-ui-playground.pages.dev/dialog?style=alert" minHeight="500px">
+<Preview src="dialog?style=alert" minHeight="500px">
 
 ```dart
 class DialogExample extends StatelessWidget {

--- a/docs/src/content/docs/Components/form.mdx
+++ b/docs/src/content/docs/Components/form.mdx
@@ -8,7 +8,7 @@ import Preview from "../../../components/Preview.astro";
 
 Builds a form with validation and easy access to form fields values.
 
-<Preview src="https://shadcn-ui-playground.pages.dev/form" minHeight="300px">
+<Preview src="form" minHeight="300px">
 
 ```dart
 class FormPage extends StatefulWidget {

--- a/docs/src/content/docs/Components/input-otp.mdx
+++ b/docs/src/content/docs/Components/input-otp.mdx
@@ -8,7 +8,7 @@ import Preview from "../../../components/Preview.astro";
 
 Accessible one-time password component with copy paste functionality.
 
-<Preview src="https://shadcn-ui-playground.pages.dev/input-otp?style=primary">
+<Preview src="input-otp?style=primary">
 
 ```dart
 ShadInputOTP(
@@ -41,7 +41,7 @@ ShadInputOTP(
 Using InputFormatters you can restrict the input characters.
 The example below shows how to restrict the input to only numbers.
 
-<Preview src="https://shadcn-ui-playground.pages.dev/input-otp?style=pattern">
+<Preview src="input-otp?style=pattern">
 
 ```dart
 ShadInputOTP(
@@ -70,7 +70,7 @@ See also `UpperCaseTextInputFormatter` and `LowerCaseTextInputFormatter` which a
 
 ## Form
 
-<Preview src="https://shadcn-ui-playground.pages.dev/form?style=inputOTPField" minHeight="300px">
+<Preview src="form?style=inputOTPField" minHeight="300px">
 
 ```dart
 ShadInputOTPFormField(

--- a/docs/src/content/docs/Components/input.mdx
+++ b/docs/src/content/docs/Components/input.mdx
@@ -8,7 +8,7 @@ import Preview from "../../../components/Preview.astro";
 
 Displays a form input field or a component that looks like an input field.
 
-<Preview src="https://shadcn-ui-playground.pages.dev/input?style=email">
+<Preview src="input?style=email">
 
 ```dart
 ConstrainedBox(
@@ -24,7 +24,7 @@ ConstrainedBox(
 
 ## With prefix and suffix
 
-<Preview src="https://shadcn-ui-playground.pages.dev/input?style=password">
+<Preview src="input?style=password">
 
 ```dart
 class PasswordInput extends StatefulWidget {
@@ -68,7 +68,7 @@ class _PasswordInputState extends State<PasswordInput> {
 
 ## Form
 
-<Preview src="https://shadcn-ui-playground.pages.dev/form?style=inputField" minHeight="300px">
+<Preview src="form?style=inputField" minHeight="300px">
 
 ```dart
 ShadInputFormField(

--- a/docs/src/content/docs/Components/popover.mdx
+++ b/docs/src/content/docs/Components/popover.mdx
@@ -8,7 +8,7 @@ import Preview from "../../../components/Preview.astro";
 
 Displays rich content in a portal, triggered by a button.
 
-<Preview src="https://shadcn-ui-playground.pages.dev/popover" minHeight="400px">
+<Preview src="popover" minHeight="400px">
 
 ```dart
 import 'package:flutter/material.dart';

--- a/docs/src/content/docs/Components/progress.mdx
+++ b/docs/src/content/docs/Components/progress.mdx
@@ -9,7 +9,7 @@ Displays an indicator showing the completion progress of a task, typically displ
 
 ## Determinate
 
-<Preview src="https://shadcn-ui-playground.pages.dev/progress">
+<Preview src="progress">
  ```dart
 ConstrainedBox(
   constraints: BoxConstraints(
@@ -22,7 +22,7 @@ ConstrainedBox(
 
 
 ## Indeterminate
-<Preview src="https://shadcn-ui-playground.pages.dev/progress?style=indeterminate">
+<Preview src="progress?style=indeterminate">
  ```dart
 ConstrainedBox(
   constraints: BoxConstraints(

--- a/docs/src/content/docs/Components/radio-group.mdx
+++ b/docs/src/content/docs/Components/radio-group.mdx
@@ -7,7 +7,7 @@ import Preview from '../../../components/Preview.astro';
 
 A set of checkable buttons—known as radio buttons—where no more than one of the buttons can be checked at a time.
 
-<Preview src="https://shadcn-ui-playground.pages.dev/radio-group">
+<Preview src="radio-group">
  ```dart
 ShadRadioGroup<String>(
   items: [
@@ -30,7 +30,7 @@ ShadRadioGroup<String>(
 
 ## Form
 
-<Preview src="https://shadcn-ui-playground.pages.dev/form?style=radioField" minHeight="300px">
+<Preview src="form?style=radioField" minHeight="300px">
  ```dart
 enum NotifyAbout {
   all,

--- a/docs/src/content/docs/Components/resizable.mdx
+++ b/docs/src/content/docs/Components/resizable.mdx
@@ -7,7 +7,7 @@ import Preview from '../../../components/Preview.astro';
 
 Resizable panel groups and layouts.
 
-<Preview src="https://shadcn-ui-playground.pages.dev/resizable?style=basic" minHeight="400px">
+<Preview src="resizable?style=basic" minHeight="400px">
 
 ```dart
 class BasicResizable extends StatelessWidget {
@@ -73,7 +73,7 @@ Try resizing a panel, then double-click on the handle to reset to the default si
 
 Use the `axis` property to change the direction of the resizable panels.
 
-<Preview src="https://shadcn-ui-playground.pages.dev/resizable?style=vertical" minHeight="400px">
+<Preview src="resizable?style=vertical" minHeight="400px">
 
 ```dart
 class VerticalResizable extends StatelessWidget {
@@ -126,7 +126,7 @@ You can show the handle by using the `showHandle` property.
 
 You can customize it using the `handleIcon` or `handleIconSrc` properties.
 
-<Preview src="https://shadcn-ui-playground.pages.dev/resizable?style=handle" minHeight="400px">
+<Preview src="resizable?style=handle" minHeight="400px">
 
 ```dart
 class HandleResizable extends StatelessWidget {

--- a/docs/src/content/docs/Components/select.mdx
+++ b/docs/src/content/docs/Components/select.mdx
@@ -8,7 +8,7 @@ import Preview from "../../../components/Preview.astro";
 
 Displays a list of options for the user to pick from—triggered by a button.
 
-<Preview src="https://shadcn-ui-playground.pages.dev/select" minHeight="300px">
+<Preview src="select" minHeight="300px">
 
 ```dart
 final fruits = {
@@ -56,7 +56,7 @@ class SelectExample extends StatelessWidget {
 
 ## Scrollable
 
-<Preview src="https://shadcn-ui-playground.pages.dev/select?style=timezone" minHeight="550px">
+<Preview src="select?style=timezone" minHeight="550px">
 
 ```dart
 final timezones = {
@@ -148,7 +148,7 @@ class SelectExample extends StatelessWidget {
 
 ## Form
 
-<Preview src="https://shadcn-ui-playground.pages.dev/form?style=selectField" minHeight="400px">
+<Preview src="form?style=selectField" minHeight="400px">
 
 ```dart
 final verifiedEmails = [
@@ -188,7 +188,7 @@ class SelectFormField extends StatelessWidget {
 
 ## With Search
 
-<Preview src="https://shadcn-ui-playground.pages.dev/select?style=frameworks" minHeight="400px">
+<Preview src="select?style=frameworks" minHeight="400px">
 
 ```dart
 const frameworks = {
@@ -262,7 +262,7 @@ This example shows how to select multiple options.
 In addition, the `allowDeselection` property is set to `true` to allow the user to deselect an option and the `closeOnSelect` property is set to `false` to keep the popover open after selecting an option.
 If you tap outside the popover, it will close.
 
-<Preview src="https://shadcn-ui-playground.pages.dev/select?style=multiple" minHeight="400px">
+<Preview src="select?style=multiple" minHeight="400px">
 
 ```dart
 final fruits = {

--- a/docs/src/content/docs/Components/sheet.mdx
+++ b/docs/src/content/docs/Components/sheet.mdx
@@ -7,7 +7,7 @@ import Preview from '../../../components/Preview.astro';
 
 Extends the Dialog component to display content that complements the main content of the screen.
 
-<Preview src="https://shadcn-ui-playground.pages.dev/sheet?style=primary" minHeight="600px">
+<Preview src="sheet?style=primary" minHeight="600px">
  ```dart
 ShadButton.outline(
   child: const Text('Open'),
@@ -78,7 +78,7 @@ class EditProfileSheet extends StatelessWidget {
 
 Use the `side` property to `showShadSheet` to indicate the edge of the screen where the component will appear. The values can be `top`, `right`, `bottom` or `left`.
 
-<Preview src="https://shadcn-ui-playground.pages.dev/sheet?style=side" minHeight="600px">
+<Preview src="sheet?style=side" minHeight="600px">
  ```dart
 Row(
   mainAxisSize: MainAxisSize.min,

--- a/docs/src/content/docs/Components/slider.mdx
+++ b/docs/src/content/docs/Components/slider.mdx
@@ -7,7 +7,7 @@ import Preview from '../../../components/Preview.astro';
 
 An input where the user selects a value from within a given range.
 
-<Preview src="https://shadcn-ui-playground.pages.dev/slider">
+<Preview src="slider">
  ```dart
 ShadSlider(
   initialValue: 33,

--- a/docs/src/content/docs/Components/switch.mdx
+++ b/docs/src/content/docs/Components/switch.mdx
@@ -8,7 +8,7 @@ import Preview from "../../../components/Preview.astro";
 
 A control that allows the user to toggle between checked and not checked.
 
-<Preview src="https://shadcn-ui-playground.pages.dev/switch">
+<Preview src="switch">
 
 ```dart
 class SwitchExample extends StatefulWidget {
@@ -36,7 +36,7 @@ class _SwitchExampleState extends State<SwitchExample> {
 
 ## Form
 
-<Preview src="https://shadcn-ui-playground.pages.dev/form?style=switchField" minHeight="300px">
+<Preview src="form?style=switchField" minHeight="300px">
  ```dart
 ShadSwitchFormField(
   id: 'terms',

--- a/docs/src/content/docs/Components/table.mdx
+++ b/docs/src/content/docs/Components/table.mdx
@@ -13,7 +13,7 @@ A responsive table component.
 Use the `ShadTable.list` widget to create a table from a two dimensional array of children.
 Use it just for **small** tables, because every child will be created.
 
-<Preview src="https://shadcn-ui-playground.pages.dev/table" minHeight="600px">
+<Preview src="table" minHeight="600px">
 
 ```dart
 import 'package:flutter/material.dart';

--- a/docs/src/content/docs/Components/tabs.mdx
+++ b/docs/src/content/docs/Components/tabs.mdx
@@ -8,7 +8,7 @@ import Preview from "../../../components/Preview.astro";
 
 A set of layered sections of content—known as tab panels—that are displayed one at a time.
 
-<Preview src="https://shadcn-ui-playground.pages.dev/tabs" minHeight="500px">
+<Preview src="tabs" minHeight="500px">
 
 ```dart
 class TabsExample extends StatelessWidget {

--- a/docs/src/content/docs/Components/time-picker.mdx
+++ b/docs/src/content/docs/Components/time-picker.mdx
@@ -8,7 +8,7 @@ import Preview from "../../../components/Preview.astro";
 
 A time picker component.
 
-<Preview src="https://shadcn-ui-playground.pages.dev/time-picker?style=primary">
+<Preview src="time-picker?style=primary">
 
 ```dart
 class PrimaryTimePicker extends StatelessWidget {
@@ -33,7 +33,7 @@ class PrimaryTimePicker extends StatelessWidget {
 
 ## Form
 
-<Preview src="https://shadcn-ui-playground.pages.dev/form?style=timePickerField" minHeight="400px">
+<Preview src="form?style=timePickerField" minHeight="400px">
 
 ```dart
 ShadTimePickerFormField(
@@ -49,7 +49,7 @@ ShadTimePickerFormField(
 
 ## ShadTimePickerFormField.period
 
-<Preview src="https://shadcn-ui-playground.pages.dev/form?style=periodTimePickerField" minHeight="400px">
+<Preview src="form?style=periodTimePickerField" minHeight="400px">
 
 ```dart
 ShadTimePickerFormField.period(

--- a/docs/src/content/docs/Components/toast.mdx
+++ b/docs/src/content/docs/Components/toast.mdx
@@ -8,7 +8,7 @@ import Preview from "../../../components/Preview.astro";
 
 A succinct message that is displayed temporarily.
 
-<Preview src="https://shadcn-ui-playground.pages.dev/toast?style=schedule" minHeight="400px">
+<Preview src="toast?style=schedule" minHeight="400px">
 
 ```dart
 ShadButton.outline(
@@ -33,7 +33,7 @@ ShadButton.outline(
 
 ## Simple
 
-<Preview src="https://shadcn-ui-playground.pages.dev/toast?style=simple" minHeight="400px">
+<Preview src="toast?style=simple" minHeight="400px">
 
 ```dart
 ShadButton.outline(
@@ -52,7 +52,7 @@ ShadButton.outline(
 
 ## With Title
 
-<Preview src="https://shadcn-ui-playground.pages.dev/toast?style=withTitle" minHeight="400px">
+<Preview src="toast?style=withTitle" minHeight="400px">
 
 ```dart
 ShadButton.outline(
@@ -73,7 +73,7 @@ ShadButton.outline(
 
 ## With Action
 
-<Preview src="https://shadcn-ui-playground.pages.dev/toast?style=withAction" minHeight="400px">
+<Preview src="toast?style=withAction" minHeight="400px">
 
 ```dart
 ShadButton.outline(
@@ -98,7 +98,7 @@ ShadButton.outline(
 
 ## Destructive
 
-<Preview src="https://shadcn-ui-playground.pages.dev/toast?style=destructive" minHeight="400px">
+<Preview src="toast?style=destructive" minHeight="400px">
 
 ```dart
 final theme = ShadTheme.of(context);

--- a/docs/src/content/docs/Components/tooltip.mdx
+++ b/docs/src/content/docs/Components/tooltip.mdx
@@ -7,7 +7,7 @@ import Preview from '../../../components/Preview.astro';
 
 A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it.
 
-<Preview src="https://shadcn-ui-playground.pages.dev/tooltip">
+<Preview src="tooltip">
  ```dart
 ShadTooltip(
   builder: (context) => const Text('Add to library'),

--- a/docs/src/content/docs/typography.mdx
+++ b/docs/src/content/docs/typography.mdx
@@ -10,7 +10,7 @@ Styles for headings, paragraphs, lists...etc
 
 ## h1Large
 
-<Preview src="https://shadcn-ui-playground.pages.dev/typography?style=h1Large">
+<Preview src="typography?style=h1Large">
  ```dart
 Text(
   'Taxing Laughter: The Joke Tax Chronicles',
@@ -21,7 +21,7 @@ Text(
 
 ## h1
 
-<Preview src="https://shadcn-ui-playground.pages.dev/typography?style=h1">
+<Preview src="typography?style=h1">
  ```dart
 Text(
   'Taxing Laughter: The Joke Tax Chronicles',
@@ -32,7 +32,7 @@ Text(
 
 ## h2
 
-<Preview src="https://shadcn-ui-playground.pages.dev/typography?style=h2">
+<Preview src="typography?style=h2">
  ```dart
 Text(
   'The People of the Kingdom',
@@ -43,7 +43,7 @@ Text(
 
 ## h3
 
-<Preview src="https://shadcn-ui-playground.pages.dev/typography?style=h3">
+<Preview src="typography?style=h3">
  ```dart
 Text(
   'The Joke Tax',
@@ -54,7 +54,7 @@ Text(
 
 ## h4
 
-<Preview src="https://shadcn-ui-playground.pages.dev/typography?style=h4">
+<Preview src="typography?style=h4">
  ```dart
 Text(
   'The king, seeing how much happier his subjects were, realized the error of his ways and repealed the joke tax.',
@@ -65,7 +65,7 @@ Text(
 
 ## p
 
-<Preview src="https://shadcn-ui-playground.pages.dev/typography?style=p">
+<Preview src="typography?style=p">
  ```dart
 Text(
   'The king, seeing how much happier his subjects were, realized the error of his ways and repealed the joke tax.',
@@ -76,7 +76,7 @@ Text(
 
 ## Blockquote
 
-<Preview src="https://shadcn-ui-playground.pages.dev/typography?style=blockquote">
+<Preview src="typography?style=blockquote">
  ```dart
 Text(
   '"After all," he said, "everyone enjoys a good joke, so it\'s only fair that they should pay for the privilege."',
@@ -87,7 +87,7 @@ Text(
 
 ## Table
 
-<Preview src="https://shadcn-ui-playground.pages.dev/typography?style=table">
+<Preview src="typography?style=table">
  ```dart
 Text(
   "King's Treasury",
@@ -98,7 +98,7 @@ Text(
 
 ## List
 
-<Preview src="https://shadcn-ui-playground.pages.dev/typography?style=list">
+<Preview src="typography?style=list">
  ```dart
 Text(
   '1st level of puns: 5 gold coins',
@@ -109,7 +109,7 @@ Text(
 
 ## Lead
 
-<Preview src="https://shadcn-ui-playground.pages.dev/typography?style=lead">
+<Preview src="typography?style=lead">
  ```dart
 Text(
   'A modal dialog that interrupts the user with important content and expects a response.',
@@ -120,7 +120,7 @@ Text(
 
 ## Large
 
-<Preview src="https://shadcn-ui-playground.pages.dev/typography?style=large">
+<Preview src="typography?style=large">
  ```dart
 Text(
   'Are you absolutely sure?',
@@ -131,7 +131,7 @@ Text(
 
 ## Small
 
-<Preview src="https://shadcn-ui-playground.pages.dev/typography?style=small">
+<Preview src="typography?style=small">
  ```dart
 Text(
   'Email address',
@@ -142,7 +142,7 @@ Text(
 
 ## Muted
 
-<Preview src="https://shadcn-ui-playground.pages.dev/typography?style=muted">
+<Preview src="typography?style=muted">
  ```dart
 Text(
   'Enter your email address.',

--- a/playground/devtools_options.yaml
+++ b/playground/devtools_options.yaml
@@ -1,0 +1,3 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:

--- a/playground/lib/main.dart
+++ b/playground/lib/main.dart
@@ -1,5 +1,4 @@
 import 'dart:js_interop';
-
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:playground/pages/accordion.dart';
@@ -79,6 +78,7 @@ class _MyAppState extends State<MyApp> {
   @override
   Widget build(BuildContext context) {
     final theme = Uri.base.queryParameters['theme'] ?? 'light';
+    final themeColor = Uri.base.queryParameters['themeColor'] ?? 'zinc'; // default theme color is zinc
 
     return ShadApp.router(
       title: 'shadcn-ui Flutter Playground',
@@ -86,11 +86,11 @@ class _MyAppState extends State<MyApp> {
       themeMode: theme == 'dark' ? ThemeMode.dark : ThemeMode.light,
       debugShowCheckedModeBanner: false,
       theme: ShadThemeData(
-        colorScheme: const ShadZincColorScheme.light(),
+        colorScheme: getShadColorScheme(themeColor, false),
         brightness: Brightness.light,
       ),
       darkTheme: ShadThemeData(
-        colorScheme: const ShadZincColorScheme.dark(),
+        colorScheme: getShadColorScheme(themeColor, true),
         brightness: Brightness.dark,
       ),
     );
@@ -329,3 +329,35 @@ final _router = GoRouter(
     ),
   ],
 );
+
+
+ShadColorScheme getShadColorScheme(String themeColor, bool isDarkMode) {
+  switch (themeColor.toLowerCase()) {
+    case 'blue':
+      return isDarkMode ? const ShadBlueColorScheme.dark() : const ShadBlueColorScheme.light();
+    case 'gray':
+      return isDarkMode ? const ShadGrayColorScheme.dark() : const ShadGrayColorScheme.light();
+    case 'green':
+      return isDarkMode ? const ShadGreenColorScheme.dark() : const ShadGreenColorScheme.light();
+    case 'neutral':
+      return isDarkMode ? const ShadNeutralColorScheme.dark() : const ShadNeutralColorScheme.light();
+    case 'orange':
+      return isDarkMode ? const ShadOrangeColorScheme.dark() : const ShadOrangeColorScheme.light();
+    case 'red':
+      return isDarkMode ? const ShadRedColorScheme.dark() : const ShadRedColorScheme.light();
+    case 'rose':
+      return isDarkMode ? const ShadRoseColorScheme.dark() : const ShadRoseColorScheme.light();
+    case 'slate':
+      return isDarkMode ? const ShadSlateColorScheme.dark() : const ShadSlateColorScheme.light();
+    case 'stone':
+      return isDarkMode ? const ShadStoneColorScheme.dark() : const ShadStoneColorScheme.light();
+    case 'violet':
+      return isDarkMode ? const ShadVioletColorScheme.dark() : const ShadVioletColorScheme.light();
+    case 'yellow':
+      return isDarkMode ? const ShadYellowColorScheme.dark() : const ShadYellowColorScheme.light();
+    case 'zinc':
+      return isDarkMode ? const ShadZincColorScheme.dark() : const ShadZincColorScheme.light();
+    default:
+      return isDarkMode ? const ShadZincColorScheme.dark() : const ShadZincColorScheme.light();
+  }
+}


### PR DESCRIPTION
# Add Theme Color Selector for Dynamic Component Previews
![Screenshot 2025-01-13 at 6 42 30 pm](https://github.com/user-attachments/assets/63ae2961-0d21-4f02-8c33-e9d87c40e6a5)

[Demo Video on YouTube](https://www.youtube.com/watch?v=tl_D5lm2RxU)
## Overview
This pull request introduces a new feature to the Flutter Shadcn UI documentation: a **theme color selector**. Users can now dynamically update the preview of all components by selecting a different theme color from a dropdown menu. Additionally, the Flutter Playground code has been updated to accept the `themeColor` query parameter and dynamically apply the selected theme color.

**Note:** You need to build the Flutter Playground web app and deploy it to preview the current changes. Alternatively, you can use my hosted version with the updated changes at: [https://flutter-shadcn-playground.web.app/](https://flutter-shadcn-playground.web.app/).




## Changes Made
### **Documentation Updates**
- **Theme Color Selector**:
  - Added a dropdown menu for selecting different theme colors in the documentation.
  - Observes changes to the `data-theme-color` attribute to dynamically update the component previews.

- **Dynamic Preview Updates**:
  - The iframe containing the Flutter component previews dynamically updates based on:
    - `theme`: Light/Dark mode.
    - `themeColor`: The selected theme color.
  - Ensures both `theme` and `themeColor` parameters are preserved in the iframe's `src`.

- **Default Behavior**:
  - Retains the existing functionality for light/dark mode toggling.
  - Falls back to the default theme color (`zinc`) when no color is selected.

### **Flutter Playground Updates**
- **Query Parameter Support**:
  - Added support for the `themeColor` query parameter in the Flutter Playground.
  - The `theme` (light/dark mode) and `themeColor` parameters are parsed from the URL.

- **Dynamic Theme Application**:
  - Implemented a function to dynamically apply the selected theme color:
    ```dart
    @override
    Widget build(BuildContext context) {
        final theme = Uri.base.queryParameters['theme'] ?? 'light';
        final themeColor = Uri.base.queryParameters['themeColor'] ?? 'zinc'; // default theme color is zinc

        return ShadApp.router(
        title: 'shadcn-ui Flutter Playground',
        routerConfig: router,
        themeMode: theme == 'dark' ? ThemeMode.dark : ThemeMode.light,
        debugShowCheckedModeBanner: false,
        theme: ShadThemeData(
            colorScheme: getShadColorScheme(themeColor, false),
            brightness: Brightness.light,
        ),
        darkTheme: ShadThemeData(
            colorScheme: getShadColorScheme(themeColor, true),
            brightness: Brightness.dark,
        ),
        );
    }
    ```

- **Color Scheme Mapping**:
  - Introduced the `getShadColorScheme` function to handle theme color mapping:
    ```dart
    ShadColorScheme getShadColorScheme(String themeColor, bool isDarkMode) {
      switch (themeColor.toLowerCase()) {
        case 'blue':
          return isDarkMode ? const ShadBlueColorScheme.dark() : const ShadBlueColorScheme.light();
        // Other colors follow the same pattern...
        case 'zinc':
        default:
          return isDarkMode ? const ShadZincColorScheme.dark() : const ShadZincColorScheme.light();
      }
    }
    ```

## Preview src link updated:
Example from `button.mdx`:
Updated the preview src links to follow the new concise format:
```md
## Primary

<Preview src="button?style=primary"> // see here I have removed the playground link
```dart
ShadButton(
  child: const Text('Primary'),
  onPressed: () {},
)

</Preview>
```

**Default Preview `src`**:
  - Updated all component preview `src` links to use a concise format (e.g., `button?style=primary`).
  - Introduced a `defaultPrefix` variable in `Preview.astro` to construct the full URL dynamically.

  Example:
  ```js
    // Default prefix for flutter playground site on localmachine
    // const defaultPrefix = "http://localhost:12345/"; 

    // Default prefix for flutter playground site hosted by the author.
    // this needs to be build again & deployed again
    // const defaultPrefix = "https://shadcn-ui-playground.pages.dev/"; 

    // Default prefix for flutter playground site hosted by the contributor (Harkirat Singh).
    // use this site to see the current changes
    const defaultPrefix = "https://flutter-shadcn-playground.web.app/" 
    const fullSrc = `${defaultPrefix}${src}`;
  ```
This allows for flexibility in hosting the Flutter Playground locally or using hosted URLs.


## Implementation Details
1. **Theme Color Selector**:
   - Observes `data-theme` and `data-theme-color` attribute changes using `MutationObserver`.
   - Updates the iframe `src` dynamically to reflect the selected theme and theme color query parameters.

2. **Default Prefix in `Preview.astro`**:
   - Introduced the `defaultPrefix` variable to manage the base URL for the Flutter Playground..
   - Supports switching between local and hosted environments by simply changing the prefix.

3. **Persistent State**:
   - The selected theme color is stored in `localStorage` for persistence across sessions.

4. **Flutter Playground Enhancements**:
    - Dynamically parses and applies `theme` and `themeColor` query parameters.
    - Added fallback behavior for default values (e.g., `zinc` for `themeColor`).

## How to Test
1. **Component Previews**:
    - Open the documentation locally or on the deployed preview.
    - Navigate to a component page (e.g., Button).
    - Use the dropdown menu to select a theme color.
    - Verify that:
        - The preview updates dynamically with the selected theme color.
        - The iframe URL includes both `theme` and `themeColor` query parameters.

2. **Flutter Playground**:
    - Open the Flutter Playground locally or hosted at https://flutter-shadcn-playground.web.app/button?themeColor=orange.
    - Test various combinations of theme and themeColor parameters to ensure proper behavior.

3. **Fallback Behavior**:
    - Remove the theme and themeColor query parameters from the URL and verify that:
    - The default theme (light) and theme color (zinc) are applied.


---

Thank you for reviewing this pull request! Please let me know if there are additional changes or improvements required.
