### PR TITLE
fix: make selectedOptionBuilder required in ShadSelect widget of withSearch constructor 

### DIFF
--- a/lib/src/components/select.dart
+++ b/lib/src/components/select.dart
@@ -89,7 +89,7 @@ class ShadSelect<T> extends StatefulWidget {
     super.key,
     this.options,
     this.optionsBuilder,
-    this.selectedOptionBuilder,
+    required this.selectedOptionBuilder,
     required ValueChanged<String> this.onSearchChanged,
     this.onChanged,
     this.popoverController,


### PR DESCRIPTION
This pr adds a required parameter to ShadSelect.withSearch factory so that users will have to provided selectedOptionBuilder when using ShadSelect. 

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making.
- [ ] I followed the [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[Contributor Guide]: [https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview](https://github.com/nank1ro/flutter-shadcn-ui/blob/main/CONTRIBUTING.md)
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Discord]: https://discord.gg/ZhRMAPNh5Y
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
