### PR TITLE
fix: validation mode doesnt not reset when `reset` is called on form state

### DIFF
--- a/lib/src/components/form/form.dart
+++ b/lib/src/components/form/form.dart
@@ -20,8 +20,8 @@ enum ShadAutovalidateMode {
   alwaysAfterFirstValidation,
 }
 
-typedef ShadFormFields = Map<Object,
-    ShadFormBuilderFieldState<ShadFormBuilderField<dynamic>, dynamic>>;
+typedef ShadFormFields
+    = Map<Object, ShadFormBuilderFieldState<ShadFormBuilderField<dynamic>, dynamic>>;
 
 class ShadForm extends StatefulWidget {
   const ShadForm({
@@ -58,9 +58,8 @@ class ShadForm extends StatefulWidget {
   }
 
   static ShadFormState? maybeOf(BuildContext context) {
-    return (context
-            .getElementForInheritedWidgetOfExactType<ShadFormScope>()
-            ?.widget as ShadFormScope?)
+    return (context.getElementForInheritedWidgetOfExactType<ShadFormScope>()?.widget
+            as ShadFormScope?)
         ?._formState;
   }
 }
@@ -91,8 +90,7 @@ class ShadFormState extends State<ShadForm> {
     super.initState();
     final mode = switch (widget.autovalidateMode) {
       ShadAutovalidateMode.always => AutovalidateMode.always,
-      ShadAutovalidateMode.onUserInteraction =>
-        AutovalidateMode.onUserInteraction,
+      ShadAutovalidateMode.onUserInteraction => AutovalidateMode.onUserInteraction,
       ShadAutovalidateMode.alwaysAfterFirstValidation ||
       ShadAutovalidateMode.disabled =>
         AutovalidateMode.disabled,
@@ -141,14 +139,12 @@ class ShadFormState extends State<ShadForm> {
     bool focusOnInvalid = true,
     bool autoScrollWhenFocusOnInvalid = false,
   }) {
-    if (widget.autovalidateMode ==
-        ShadAutovalidateMode.alwaysAfterFirstValidation) {
+    if (widget.autovalidateMode == ShadAutovalidateMode.alwaysAfterFirstValidation) {
       autovalidateMode.value = AutovalidateMode.always;
     }
     final hasError = !_formKey.currentState!.validate();
     if (hasError) {
-      final wrongFields =
-          _fields.values.where((element) => element.hasError).toList();
+      final wrongFields = _fields.values.where((element) => element.hasError).toList();
       if (wrongFields.isNotEmpty) {
         if (focusOnInvalid) {
           wrongFields.first.focus();
@@ -173,6 +169,7 @@ class ShadFormState extends State<ShadForm> {
   }
 
   void reset() {
+    autovalidateMode.value = widget.autovalidateMode;
     _formKey.currentState?.reset();
   }
 
@@ -218,6 +215,5 @@ class ShadFormScope extends InheritedWidget {
   ShadForm get form => _formState.widget;
 
   @override
-  bool updateShouldNotify(ShadFormScope oldWidget) =>
-      oldWidget._formState != _formState;
+  bool updateShouldNotify(ShadFormScope oldWidget) => oldWidget._formState != _formState;
 }

--- a/lib/src/components/form/form.dart
+++ b/lib/src/components/form/form.dart
@@ -169,7 +169,14 @@ class ShadFormState extends State<ShadForm> {
   }
 
   void reset() {
-    autovalidateMode.value = widget.autovalidateMode;
+    final mode = switch (widget.autovalidateMode) {
+      ShadAutovalidateMode.always => AutovalidateMode.always,
+      ShadAutovalidateMode.onUserInteraction => AutovalidateMode.onUserInteraction,
+      ShadAutovalidateMode.alwaysAfterFirstValidation ||
+      ShadAutovalidateMode.disabled =>
+        AutovalidateMode.disabled,
+    };
+    autovalidateMode.value = mode;
     _formKey.currentState?.reset();
   }
 


### PR DESCRIPTION
When `validate` is called and our validation mode is `alwaysAfterFirstValidation` we will set the mode permanently to `always` internally. 

When `reset` is called on a form state key the all subsequent text field validation gets called and all the will fail the validation since the field has been reset. This is not expected behavior. The validation mode should also be reset when `reset` is called so everything is truly reset.