### PR TITLE
fix: resizable divider alignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.23.1
+
+- **FIX**: `ShadResizable` divider alignments when `dividerSize` is overriden.
+
 ## 0.23.0
 
 - **FIX**: Expose `ShadMouseCursorProvider`.

--- a/lib/src/components/resizable.dart
+++ b/lib/src/components/resizable.dart
@@ -490,6 +490,7 @@ class ShadResizablePanelGroupState extends State<ShadResizablePanelGroup> {
         radius: const BorderRadius.all(Radius.circular(4)),
         width: 0,
       ),
+      disableSecondaryBorder: true,
     )
         .mergeWith(theme.resizableTheme.handleDecoration)
         .mergeWith(widget.handleDecoration);
@@ -603,22 +604,14 @@ class ShadResizablePanelGroupState extends State<ShadResizablePanelGroup> {
                         0,
                         (previousValue, element) => previousValue + element,
                       );
+
               leadingPosition = isHorizontal
                   ? leadingPosition * constraints.maxWidth / controller.base
                   : leadingPosition * constraints.maxHeight / controller.base;
 
-              leadingPosition -=
-                  effectiveDividerSize / 2 + effectiveDividerThickness / 2;
-
-              if (effectiveShowHandle) {
-                leadingPosition -= (isHorizontal
-                        ? effectiveHandlePadding.horizontal
-                        : effectiveHandlePadding.vertical) /
-                    2;
-                if (!theme.disableSecondaryBorder) {
-                  leadingPosition -= effectiveHandleSize / 2;
-                }
-              }
+              leadingPosition -= effectiveDividerSize > effectiveHandleSize
+                  ? effectiveDividerSize / 2
+                  : effectiveHandleSize / 2;
 
               dividers.add(
                 Positioned(
@@ -685,7 +678,6 @@ class ShadResizablePanelGroupState extends State<ShadResizablePanelGroup> {
             }
 
             return Stack(
-              fit: StackFit.expand,
               alignment: AlignmentDirectional.center,
               children: [
                 child,

--- a/lib/src/theme/themes/default_theme_no_secondary_border_variant.dart
+++ b/lib/src/theme/themes/default_theme_no_secondary_border_variant.dart
@@ -724,6 +724,7 @@ class ShadDefaultThemeNoSecondaryBorderVariant extends ShadThemeVariant {
           radius: const BorderRadius.all(Radius.circular(4)),
           width: 0,
         ),
+        disableSecondaryBorder: true,
       ),
       handleSize: 10,
       mainAxisAlignment: MainAxisAlignment.start,

--- a/lib/src/theme/themes/default_theme_variant.dart
+++ b/lib/src/theme/themes/default_theme_variant.dart
@@ -701,6 +701,7 @@ class ShadDefaultThemeVariant extends ShadThemeVariant {
           radius: const BorderRadius.all(Radius.circular(4)),
           width: 0,
         ),
+        disableSecondaryBorder: true,
       ),
       handleSize: 10,
       mainAxisAlignment: MainAxisAlignment.start,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shadcn_ui
 description: shadcn-ui ported in Flutter. Awesome UI components for Flutter, fully customizable.
-version: 0.23.0
+version: 0.23.1
 homepage: https://flutter-shadcn-ui.mariuti.com
 repository: https://github.com/nank1ro/flutter-shadcn-ui
 documentation: https://flutter-shadcn-ui.mariuti.com


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
-->

closes #333 

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making.
- [ ] I followed the [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[Contributor Guide]: [https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview](https://github.com/nank1ro/flutter-shadcn-ui/blob/main/CONTRIBUTING.md)
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Discord]: https://discord.gg/ZhRMAPNh5Y
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved alignment of dividers in the resizable component when custom sizes are applied.
- **New Features**
  - Introduced customization to disable the secondary border on resizable panel handles.
- **Chores**
  - Updated the package version to 0.23.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->