### PR TITLE
feat: add copyWith method to ShadColorScheme

### DIFF
--- a/lib/src/theme/color_scheme/base.dart
+++ b/lib/src/theme/color_scheme/base.dart
@@ -126,6 +126,8 @@ class ShadColorScheme {
     );
   }
 
+  /// Creates a copy of this [ShadColorScheme] but with the given fields replaced
+  /// with the new values.
   ShadColorScheme copyWith({
     Color? background,
     Color? foreground,

--- a/lib/src/theme/color_scheme/base.dart
+++ b/lib/src/theme/color_scheme/base.dart
@@ -126,6 +126,53 @@ class ShadColorScheme {
     );
   }
 
+  ShadColorScheme copyWith({
+    Color? background,
+    Color? foreground,
+    Color? card,
+    Color? cardForeground,
+    Color? popover,
+    Color? popoverForeground,
+    Color? primary,
+    Color? primaryForeground,
+    Color? secondary,
+    Color? secondaryForeground,
+    Color? muted,
+    Color? mutedForeground,
+    Color? accent,
+    Color? accentForeground,
+    Color? destructive,
+    Color? destructiveForeground,
+    Color? border,
+    Color? input,
+    Color? ring,
+    Color? selection,
+  }) {
+    return ShadColorScheme(
+      background: background ?? this.background,
+      foreground: foreground ?? this.foreground,
+      card: card ?? this.card,
+      cardForeground: cardForeground ?? this.cardForeground,
+      popover: popover ?? this.popover,
+      popoverForeground: popoverForeground ?? this.popoverForeground,
+      primary: primary ?? this.primary,
+      primaryForeground: primaryForeground ?? this.primaryForeground,
+      secondary: secondary ?? this.secondary,
+      secondaryForeground: secondaryForeground ?? this.secondaryForeground,
+      muted: muted ?? this.muted,
+      mutedForeground: mutedForeground ?? this.mutedForeground,
+      accent: accent ?? this.accent,
+      accentForeground: accentForeground ?? this.accentForeground,
+      destructive: destructive ?? this.destructive,
+      destructiveForeground:
+          destructiveForeground ?? this.destructiveForeground,
+      border: border ?? this.border,
+      input: input ?? this.input,
+      ring: ring ?? this.ring,
+      selection: selection ?? this.selection,
+    );
+  }
+
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;


### PR DESCRIPTION
Adds `copyWith` method to `ShadColorScheme` base class.

completes: #335

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read and followed the [Flutter Style Guide].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making.
- [X] I followed the [Data Driven Fixes] where supported.
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[Contributor Guide]: [https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview](https://github.com/nank1ro/flutter-shadcn-ui/blob/main/CONTRIBUTING.md)
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Discord]: https://discord.gg/ZhRMAPNh5Y
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced theme customization, allowing users to adjust color settings more flexibly by selectively modifying individual options while preserving default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->