### PR TITLE
feat(deps): upgrade lucide_icons_flutter to v2.0.6

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
     sdk: flutter
   flutter_svg: ^2.0.16
   intl: ^0.19.0
-  lucide_icons_flutter: ^1.2.5
+  lucide_icons_flutter: ^2.0.6
   # used by Table
   two_dimensional_scrollables: ^0.3.3
   universal_image: ^1.0.8


### PR DESCRIPTION
## Changes
- Upgraded lucide_icons_flutter from 1.2.5 to 2.0.6

All tests are passing and there are no issues when manually clicking on the example app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the version of the `lucide_icons_flutter` dependency to improve compatibility and access to the latest features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->