### PR TITLE
refactor/shad app custom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.26.0
+
+- **BREAKING CHANGE**: Update the `appBuilder` of the `ShadApp` by removing the `ThemeData` parameter.
+- **REFACTOR**: Deprecate `ShadApp.material`, `ShadApp.materialRouter`, `ShadApp.cupertino` and `ShadApp.cupertinoRouter`. Use `ShadApp.custom` instead.
+
 ## 0.25.1
 
 - **FIX**: The scrollbar of the `ShadTextarea` component has been fixed, added `scrollbarPadding` to `ShadTextareaTheme` and `ShadInputTheme`.

--- a/docs/src/content/docs/index.md
+++ b/docs/src/content/docs/index.md
@@ -136,6 +136,10 @@ ThemeData(
 ),
 ```
 
+:::note
+Use `Theme.of(context).copyWith(...)` to override the default theme, without losing the default values provided by shadcn_ui.
+:::
+
 ## Shadcn + Cupertino
 
 If you need to use shadcn components with Cupertino components, use `CupertinoApp` instead of `MaterialApp`, like you are already used to.
@@ -193,3 +197,7 @@ CupertinoThemeData(
   brightness: themeData.brightness,
 ),
 ```
+
+:::note
+Use `CupertinoTheme.of(context).copyWith(...)` to override the default theme, without losing the default values provided by shadcn_ui.
+:::

--- a/docs/src/content/docs/index.md
+++ b/docs/src/content/docs/index.md
@@ -70,40 +70,29 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
 -    return ShadApp();
-+    return ShadApp.material();
++    return ShadApp.custom(
++      themeMode: ThemeMode.dark,
++      darkTheme: ShadThemeData(
++        brightness: Brightness.dark,
++        colorScheme: const ShadSlateColorScheme.dark(),
++      ),
++      appBuilder: (context, theme) {
++        return MaterialApp(
++          theme: theme,
++          builder: (context, child) {
++            return ShadAppBuilder(child: child!);
++          },
++        );
++      },
++    );
   }
 ```
 
 :::tip
-If you need to use the `Router` instead of the `Navigator`, use `ShadApp.materialRouter`.
+If you need to use the `Router` instead of the `Navigator`, use `MaterialApp.router`.
 :::
 
 ---
-
-The `ShadApp` widget automatically creates a Material `ThemeData`.
-If you need to customize the Material theme use `materialThemeBuilder`:
-
-```diff lang="dart"
-import 'package:shadcn_ui/shadcn_ui.dart';
-
-void main() {
-  runApp(const MyApp());
-}
-
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return ShadApp.material(
-+      materialThemeBuilder: (context, theme) {
-+        return theme.copyWith(
-+          appBarTheme: const AppBarTheme(toolbarHeight: 52),
-+        );
-+      },
-    );
-  }
-```
 
 The default Material `ThemeData` created by `ShadApp` is:
 
@@ -137,83 +126,22 @@ ThemeData(
     size: 16,
     color: themeData.colorScheme.foreground,
   ),
+  scrollbarTheme: ScrollbarThemeData(
+    crossAxisMargin: 1,
+    mainAxisMargin: 1,
+    thickness: const WidgetStatePropertyAll(8),
+    radius: const Radius.circular(999),
+    thumbColor: WidgetStatePropertyAll(themeData.colorScheme.border),
+  ),
 ),
 ```
 
 ## Shadcn + Cupertino
 
-If you need to use shadcn components with Cupertino components, use `ShadApp.cupertino`.
+If you need to use shadcn components with Cupertino components, use `CupertinoApp` instead of `MaterialApp`, like you are already used to.
 
 ```diff lang="dart"
 import 'package:shadcn_ui/shadcn_ui.dart';
-
-void main() {
-  runApp(const MyApp());
-}
-
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
-
-  @override
-  Widget build(BuildContext context) {
--    return ShadApp();
-+    return ShadApp.cupertino();
-  }
-```
-
-:::tip
-If you need to use the `Router` instead of the `Navigator`, use `ShadApp.cupertinoRouter`.
-:::
-
----
-
-The `ShadApp` widget automatically creates a `CupertinoThemeData` and a Material `ThemeData`.
-If you need to customize the Material theme use `materialThemeBuilder`, and `cupertinoThemeBuilder` to customize the Cupertino theme:
-
-```diff lang="dart"
-import 'package:shadcn_ui/shadcn_ui.dart';
-
-void main() {
-  runApp(const MyApp());
-}
-
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return ShadApp.cupertino(
-+      cupertinoThemeBuilder: (context, theme) {
-+        return theme.copyWith(applyThemeToAll: true);
-+      },
-+      materialThemeBuilder: (context, theme) {
-+        return theme.copyWith(
-+          appBarTheme: const AppBarTheme(toolbarHeight: 52),
-+        );
-+      },
-    );
-  }
-```
-
-The default `CupertinoThemeData` created by `ShadApp` is:
-
-```dart
-CupertinoThemeData(
-  primaryColor: themeData.colorScheme.primary,
-  primaryContrastingColor: themeData.colorScheme.primaryForeground,
-  scaffoldBackgroundColor: themeData.colorScheme.background,
-  barBackgroundColor: themeData.colorScheme.primary,
-  brightness: themeData.brightness,
-),
-```
-
-## Shadcn + Custom App
-
-If you want to integrate Shadcn with a custom WidgetsApp integration, like GetX (GetMaterialApp) you can use `ShadApp.custom`
-
-```diff lang="dart"
-import 'package:shadcn_ui/shadcn_ui.dart';
-+ import 'package:get/get.dart';
 
 void main() {
   runApp(const MyApp());
@@ -226,12 +154,41 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
 -    return ShadApp();
 +    return ShadApp.custom(
-+      appBuilder: (context, theme) => GetMaterialApp(
-+        theme: theme,
-+        builder: (context, child) {
-+          return ShadToaster(child: child!);
-+        },
++      themeMode: ThemeMode.dark,
++      darkTheme: ShadThemeData(
++        brightness: Brightness.dark,
++        colorScheme: const ShadSlateColorScheme.dark(),
 +      ),
++      appBuilder: (context, theme) {
++        return CupertinoApp(
++          localizationsDelegates: const [
++            DefaultMaterialLocalizations.delegate,
++            DefaultCupertinoLocalizations.delegate,
++            DefaultWidgetsLocalizations.delegate,
++          ],
++          builder: (context, child) {
++            return ShadAppBuilder(child: child!);
++          },
++        );
++      },
 +    );
   }
+```
+
+:::tip
+If you need to use the `Router` instead of the `Navigator`, use `CupertinoApp.router`.
+:::
+
+---
+
+The default `CupertinoThemeData` created by `ShadApp` is:
+
+```dart
+CupertinoThemeData(
+  primaryColor: themeData.colorScheme.primary,
+  primaryContrastingColor: themeData.colorScheme.primaryForeground,
+  scaffoldBackgroundColor: themeData.colorScheme.background,
+  barBackgroundColor: themeData.colorScheme.primary,
+  brightness: themeData.brightness,
+),
 ```

--- a/docs/src/content/docs/index.md
+++ b/docs/src/content/docs/index.md
@@ -76,9 +76,9 @@ class MyApp extends StatelessWidget {
 +        brightness: Brightness.dark,
 +        colorScheme: const ShadSlateColorScheme.dark(),
 +      ),
-+      appBuilder: (context, theme) {
++      appBuilder: (context) {
 +        return MaterialApp(
-+          theme: theme,
++          theme: Theme.of(context),
 +          builder: (context, child) {
 +            return ShadAppBuilder(child: child!);
 +          },
@@ -159,8 +159,9 @@ class MyApp extends StatelessWidget {
 +        brightness: Brightness.dark,
 +        colorScheme: const ShadSlateColorScheme.dark(),
 +      ),
-+      appBuilder: (context, theme) {
++      appBuilder: (context) {
 +        return CupertinoApp(
++          theme: CupertinoTheme.of(context),
 +          localizationsDelegates: const [
 +            DefaultMaterialLocalizations.delegate,
 +            DefaultCupertinoLocalizations.delegate,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -115,9 +115,10 @@ class App extends StatelessWidget {
         //     brightness: Brightness.dark,
         //     colorScheme: const ShadSlateColorScheme.dark(),
         //   ),
-        //   appBuilder: (context, theme) {
+        //   appBuilder: (context) {
         //     return MaterialApp(
         //       routes: routes,
+        //       theme: Theme.of(context),
         //       home: const MainPage(),
         //       builder: (context, child) {
         //         return ShadAppBuilder(child: child!);

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -111,15 +111,19 @@ class App extends StatelessWidget {
         // Custom App example
         // return ShadApp.custom(
         //   themeMode: themeMode,
-        //   appBuilder: (context, theme) => GetMaterialApp(
-        //     routes: routes,
-        //     themeMode: themeMode,
-        //     theme: theme,
-        //     home: const MainPage(),
-        //     builder: (context, child) {
-        //       return ShadToaster(child: child!);
-        //     },
+        //   darkTheme: ShadThemeData(
+        //     brightness: Brightness.dark,
+        //     colorScheme: const ShadSlateColorScheme.dark(),
         //   ),
+        //   appBuilder: (context, theme) {
+        //     return MaterialApp(
+        //       routes: routes,
+        //       home: const MainPage(),
+        //       builder: (context, child) {
+        //         return ShadAppBuilder(child: child!);
+        //       },
+        //     );
+        //   },
         // );
         return ShadApp(
           debugShowCheckedModeBanner: false,

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -299,8 +299,7 @@ class ShadApp extends StatefulWidget {
 
   const ShadApp.custom({
     super.key,
-    required Widget Function(BuildContext context, ThemeData theme)
-        this.appBuilder,
+    required WidgetBuilder this.appBuilder,
     this.theme,
     this.darkTheme,
     this.themeMode,
@@ -595,7 +594,7 @@ class ShadApp extends StatefulWidget {
   final Curve themeCurve;
 
   /// A custom app widget builder.
-  final Widget Function(BuildContext context, ThemeData theme)? appBuilder;
+  final WidgetBuilder? appBuilder;
 
   final ThemeData Function(BuildContext context, ThemeData theme)?
       materialThemeBuilder;
@@ -972,7 +971,7 @@ class _ShadAppState extends State<ShadApp> {
               // surround widget.builder with yet another builder so that
               // a context separates them and Theme.of() correctly
               // resolves to the theme we passed to AnimatedTheme.
-              return widget.appBuilder!(context, Theme.of(context));
+              return widget.appBuilder!(context);
             },
           ),
         );

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -760,28 +760,6 @@ class _ShadAppState extends State<ShadApp> {
       builder: widget.builder,
       child: child,
     );
-    // return ShadToaster(
-    //   child: ShadSonner(
-    //     child: widget.builder != null
-    //         ? Builder(
-    //             builder: (BuildContext context) {
-    //               // Why are we surrounding a builder with a builder?
-    //               //
-    //               // The widget.builder may contain code that invokes
-    //               // Theme.of(), which should return the theme we selected
-    //               // above in AnimatedTheme. However, if we invoke
-    //               // widget.builder() directly as the child of AnimatedTheme
-    //               // then there is no Context separating them, and the
-    //               // widget.builder() will not find the theme. Therefore, we
-    //               // surround widget.builder with yet another builder so that
-    //               // a context separates them and Theme.of() correctly
-    //               // resolves to the theme we passed to AnimatedTheme.
-    //               return widget.builder!(context, child);
-    //             },
-    //           )
-    //         : child ?? const SizedBox.shrink(),
-    //   ),
-    // );
   }
 
   Widget _buildApp(BuildContext context) {

--- a/lib/src/app.dart
+++ b/lib/src/app.dart
@@ -110,6 +110,10 @@ class ShadApp extends StatefulWidget {
         type = ShadAppType.shadcn;
 
   /// Creates a [MaterialApp] wrapped by a [ShadTheme].
+  @Deprecated(
+    'Use ShadApp.custom instead. '
+    'This constructor will be removed in a future version.',
+  )
   const ShadApp.material({
     super.key,
     this.navigatorKey,
@@ -153,6 +157,10 @@ class ShadApp extends StatefulWidget {
         type = ShadAppType.material;
 
   /// Creates a [MaterialApp] wrapped by a [ShadTheme] that uses the [Router] instead of a [Navigator].
+  @Deprecated(
+    'Use ShadApp.custom instead. '
+    'This constructor will be removed in a future version.',
+  )
   const ShadApp.materialRouter({
     super.key,
     this.theme,
@@ -196,6 +204,10 @@ class ShadApp extends StatefulWidget {
         type = ShadAppType.material;
 
   /// Creates a [CupertinoApp] wrapped by a [ShadTheme].
+  @Deprecated(
+    'Use ShadApp.custom instead. '
+    'This constructor will be removed in a future version.',
+  )
   const ShadApp.cupertino({
     super.key,
     this.navigatorKey,
@@ -239,6 +251,10 @@ class ShadApp extends StatefulWidget {
         type = ShadAppType.cupertino;
 
   /// Creates a [CupertinoApp] wrapped by a [ShadTheme] that uses the [Router] instead of a [Navigator].
+  @Deprecated(
+    'Use ShadApp.custom instead. '
+    'This constructor will be removed in a future version.',
+  )
   const ShadApp.cupertinoRouter({
     super.key,
     this.theme,
@@ -645,6 +661,15 @@ class _ShadAppState extends State<ShadApp> {
     );
   }
 
+  ShadThemeData get effectiveLightTheme =>
+      widget.theme ??
+      ShadThemeData(
+        colorScheme: const ShadSlateColorScheme.light(),
+        brightness: Brightness.light,
+      );
+
+  ShadThemeData? get effectiveDarkTheme => widget.darkTheme;
+
   ShadThemeData theme(BuildContext context) {
     final mode = widget.themeMode ?? ThemeMode.system;
     final platformBrightness = MediaQuery.platformBrightnessOf(context);
@@ -653,13 +678,9 @@ class _ShadAppState extends State<ShadApp> {
 
     final data = () {
       late ShadThemeData result;
-      final lightTheme = widget.theme ??
-          ShadThemeData(
-            colorScheme: const ShadSlateColorScheme.light(),
-            brightness: Brightness.light,
-          );
+      final lightTheme = effectiveLightTheme;
       if (useDarkStyle) {
-        result = widget.darkTheme ?? lightTheme;
+        result = effectiveDarkTheme ?? lightTheme;
       } else {
         result = lightTheme;
       }
@@ -735,28 +756,32 @@ class _ShadAppState extends State<ShadApp> {
   }
 
   Widget _builder(BuildContext context, Widget? child) {
-    return ShadToaster(
-      child: ShadSonner(
-        child: widget.builder != null
-            ? Builder(
-                builder: (BuildContext context) {
-                  // Why are we surrounding a builder with a builder?
-                  //
-                  // The widget.builder may contain code that invokes
-                  // Theme.of(), which should return the theme we selected
-                  // above in AnimatedTheme. However, if we invoke
-                  // widget.builder() directly as the child of AnimatedTheme
-                  // then there is no Context separating them, and the
-                  // widget.builder() will not find the theme. Therefore, we
-                  // surround widget.builder with yet another builder so that
-                  // a context separates them and Theme.of() correctly
-                  // resolves to the theme we passed to AnimatedTheme.
-                  return widget.builder!(context, child);
-                },
-              )
-            : child ?? const SizedBox.shrink(),
-      ),
+    return ShadAppBuilder(
+      builder: widget.builder,
+      child: child,
     );
+    // return ShadToaster(
+    //   child: ShadSonner(
+    //     child: widget.builder != null
+    //         ? Builder(
+    //             builder: (BuildContext context) {
+    //               // Why are we surrounding a builder with a builder?
+    //               //
+    //               // The widget.builder may contain code that invokes
+    //               // Theme.of(), which should return the theme we selected
+    //               // above in AnimatedTheme. However, if we invoke
+    //               // widget.builder() directly as the child of AnimatedTheme
+    //               // then there is no Context separating them, and the
+    //               // widget.builder() will not find the theme. Therefore, we
+    //               // surround widget.builder with yet another builder so that
+    //               // a context separates them and Theme.of() correctly
+    //               // resolves to the theme we passed to AnimatedTheme.
+    //               return widget.builder!(context, child);
+    //             },
+    //           )
+    //         : child ?? const SizedBox.shrink(),
+    //   ),
+    // );
   }
 
   Widget _buildApp(BuildContext context) {
@@ -1024,5 +1049,48 @@ class ShadScrollBehavior extends ScrollBehavior {
             return child;
         }
     }
+  }
+}
+
+/// {@template ShadAppBuilder}
+/// The builder for an `*App` instance.
+///
+/// Must be placed in the builder of the `*App` widget.
+/// {@endtemplate}
+class ShadAppBuilder extends StatelessWidget {
+  /// {@macro ShadAppBuilder}
+  const ShadAppBuilder({
+    super.key,
+    this.builder,
+    this.child,
+  });
+
+  final TransitionBuilder? builder;
+  final Widget? child;
+
+  @override
+  Widget build(BuildContext context) {
+    return ShadToaster(
+      child: ShadSonner(
+        child: builder != null
+            ? Builder(
+                builder: (BuildContext context) {
+                  // Why are we surrounding a builder with a builder?
+                  //
+                  // The widget.builder may contain code that invokes
+                  // Theme.of(), which should return the theme we selected
+                  // above in AnimatedTheme. However, if we invoke
+                  // widget.builder() directly as the child of AnimatedTheme
+                  // then there is no Context separating them, and the
+                  // widget.builder() will not find the theme. Therefore, we
+                  // surround widget.builder with yet another builder so that
+                  // a context separates them and Theme.of() correctly
+                  // resolves to the theme we passed to AnimatedTheme.
+                  return builder!(context, child);
+                },
+              )
+            : child ?? const SizedBox.shrink(),
+      ),
+    );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shadcn_ui
 description: shadcn/ui ported in Flutter. Awesome UI components for Flutter, fully customizable.
-version: 0.25.1
+version: 0.26.0
 homepage: https://flutter-shadcn-ui.mariuti.com
 repository: https://github.com/nank1ro/flutter-shadcn-ui
 documentation: https://flutter-shadcn-ui.mariuti.com


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
-->

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making.
- [ ] I followed the [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[Contributor Guide]: [https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview](https://github.com/nank1ro/flutter-shadcn-ui/blob/main/CONTRIBUTING.md)
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Discord]: https://discord.gg/ZhRMAPNh5Y
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated usage examples and guidance to recommend `ShadApp.custom` with direct `MaterialApp` or `CupertinoApp` integration, replacing previous constructors and examples.
  - Clarified best practices for theme customization and app integration.
  - Removed outdated examples and tips for older constructors.
  - Added notes on default scrollbar theme settings in Material theme.

- **New Features**
  - Introduced a new `ShadAppBuilder` widget to simplify wrapping children with Shadcn UI features.

- **Refactor**
  - Deprecated older constructors (`ShadApp.material`, `.cupertino`, etc.) in favor of a unified custom approach.
  - Refactored internal app builder logic to use `ShadAppBuilder` for consistent theming and widget wrapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->