### PR TITLE
chore: pass supported deviced to shad gesture detector

### DIFF
--- a/lib/src/components/context_menu.dart
+++ b/lib/src/components/context_menu.dart
@@ -38,6 +38,7 @@ class ShadContextMenuRegion extends StatefulWidget {
     this.decoration,
     this.filter,
     this.controller,
+    this.supportedDevices,
     this.longPressEnabled,
   });
 
@@ -78,6 +79,13 @@ class ShadContextMenuRegion extends StatefulWidget {
 
   /// {@macro ShadContextMenu.controller}
   final ShadContextMenuController? controller;
+
+  /// The kind of devices that are allowed to be recognized.
+  ///
+  /// If set to null, events from all device types will be recognized. Defaults
+  /// to null.
+  final Set<PointerDeviceKind>? supportedDevices;
+
 
   /// {@template ShadContextMenuRegion.longPressEnabled}
   /// Whether the context menu should be shown when the user long presses the
@@ -153,6 +161,7 @@ class _ShadContextMenuRegionState extends State<ShadContextMenuRegion> {
       decoration: widget.decoration,
       filter: widget.filter,
       child: ShadGestureDetector(
+        supportedDevices: widget.supportedDevices,
         onTapDown: (_) => hide(),
         onSecondaryTapDown: (d) async {
           if (kIsWeb && !isContextMenuAlreadyDisabled) {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
-->

Pass supported devices down to gesture detector. Currently when using a stylus for drawing, the context menu will pop.

https://github.com/nank1ro/flutter-shadcn-ui/issues/361
## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making.
- [ ] I followed the [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[Contributor Guide]: [https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview](https://github.com/nank1ro/flutter-shadcn-ui/blob/main/CONTRIBUTING.md)
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Discord]: https://discord.gg/ZhRMAPNh5Y
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying which input device types (such as mouse, touch, etc.) can trigger context menus. If not set, all device types are recognized by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->