### PR TITLE
refactor: decoration secondary border

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.27.0
+
+- **BREAKING CHANGE**: The secondary border of `ShadDecoration` now is drawn outward of the widget, without consuming any extra space. This change affects all components that are focusable.
+- **FEAT**: Add `offset` to `ShadBorder` to set the offset between the widget and the outward secondary border.
+
 ## 0.26.5
 
 - **CHORE**: Update lower bound dependency versions.

--- a/lib/src/theme/components/decorator.dart
+++ b/lib/src/theme/components/decorator.dart
@@ -354,15 +354,18 @@ class ShadDecorator extends StatelessWidget {
     );
 
     if (secondaryBorder != null && !effectiveDisableSecondaryBorder) {
-      decorated = CustomPaint(
-        foregroundPainter: ShadOutwardBorderPainter(
-          border: secondaryBorder.toBorder(),
-          offset: secondaryBorder.offset ?? 0,
-          radius: secondaryBorder.radius?.resolve(textDirection) ??
-              BorderRadius.zero,
-          textDirection: textDirection,
+      decorated = Padding(
+        padding: secondaryBorder.padding ?? EdgeInsets.zero,
+        child: CustomPaint(
+          foregroundPainter: ShadOutwardBorderPainter(
+            border: secondaryBorder.toBorder(),
+            offset: secondaryBorder.offset ?? 0,
+            radius: secondaryBorder.radius?.resolve(textDirection) ??
+                BorderRadius.zero,
+            textDirection: textDirection,
+          ),
+          child: decorated,
         ),
-        child: decorated,
       );
     }
 

--- a/lib/src/theme/components/decorator.dart
+++ b/lib/src/theme/components/decorator.dart
@@ -294,6 +294,7 @@ class ShadDecorator extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = ShadTheme.of(context);
+    final textDirection = Directionality.of(context);
 
     final effectiveDecoration = theme.decoration.mergeWith(decoration);
 
@@ -354,46 +355,53 @@ class ShadDecorator extends StatelessWidget {
 
     if (secondaryBorder != null && !effectiveDisableSecondaryBorder) {
       decorated = CustomPaint(
-        foregroundPainter: MyCustomPainter(
+        foregroundPainter: ShadOutwardBorderPainter(
           border: secondaryBorder.toBorder(),
-          delta: 4,
-          radius: secondaryBorder.radius?.resolve(Directionality.of(context)) ??
+          delta: secondaryBorder.offset ?? 0,
+          radius: secondaryBorder.radius?.resolve(textDirection) ??
               BorderRadius.zero,
+          textDirection: textDirection,
         ),
         child: decorated,
       );
-      // decorated = Container(
-      //   decoration: BoxDecoration(
-      //     border: secondaryBorder.hasBorder ? secondaryBorder.toBorder() : null,
-      //     borderRadius: secondaryBorder.radius,
-      //   ),
-      //   padding: secondaryBorder.padding,
-      //   child: decorated,
-      // );
     }
 
     return decorated;
   }
 }
 
-class MyCustomPainter extends CustomPainter {
-  const MyCustomPainter({
+/// {@template shadOutwardBorderPainter}
+/// A [CustomPainter] that paints a border outward from the given rectangle.
+/// {@endtemplate}
+class ShadOutwardBorderPainter extends CustomPainter {
+  /// {@macro shadOutwardBorderPainter}
+  const ShadOutwardBorderPainter({
     required this.border,
     required this.delta,
     required this.radius,
+    required this.textDirection,
   });
 
   final Border border;
   final double delta;
   final BorderRadius? radius;
+  final TextDirection? textDirection;
+
   @override
   void paint(Canvas canvas, Size size) {
-    border.paint(canvas, (Offset.zero & size).inflate(delta),
-        borderRadius: radius);
+    border.paint(
+      canvas,
+      (Offset.zero & size).inflate(delta),
+      borderRadius: radius,
+      textDirection: textDirection,
+    );
   }
 
   @override
-  bool shouldRepaint(covariant CustomPainter oldDelegate) {
-    return true;
+  bool shouldRepaint(covariant ShadOutwardBorderPainter oldDelegate) {
+    return border != oldDelegate.border ||
+        delta != oldDelegate.delta ||
+        radius != oldDelegate.radius ||
+        textDirection != oldDelegate.textDirection;
   }
 }

--- a/lib/src/theme/components/decorator.dart
+++ b/lib/src/theme/components/decorator.dart
@@ -353,16 +353,47 @@ class ShadDecorator extends StatelessWidget {
     );
 
     if (secondaryBorder != null && !effectiveDisableSecondaryBorder) {
-      decorated = Container(
-        decoration: BoxDecoration(
-          border: secondaryBorder.hasBorder ? secondaryBorder.toBorder() : null,
-          borderRadius: secondaryBorder.radius,
+      decorated = CustomPaint(
+        foregroundPainter: MyCustomPainter(
+          border: secondaryBorder.toBorder(),
+          delta: 4,
+          radius: secondaryBorder.radius?.resolve(Directionality.of(context)) ??
+              BorderRadius.zero,
         ),
-        padding: secondaryBorder.padding,
         child: decorated,
       );
+      // decorated = Container(
+      //   decoration: BoxDecoration(
+      //     border: secondaryBorder.hasBorder ? secondaryBorder.toBorder() : null,
+      //     borderRadius: secondaryBorder.radius,
+      //   ),
+      //   padding: secondaryBorder.padding,
+      //   child: decorated,
+      // );
     }
 
     return decorated;
+  }
+}
+
+class MyCustomPainter extends CustomPainter {
+  const MyCustomPainter({
+    required this.border,
+    required this.delta,
+    required this.radius,
+  });
+
+  final Border border;
+  final double delta;
+  final BorderRadius? radius;
+  @override
+  void paint(Canvas canvas, Size size) {
+    border.paint(canvas, (Offset.zero & size).inflate(delta),
+        borderRadius: radius);
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) {
+    return true;
   }
 }

--- a/lib/src/theme/components/decorator.dart
+++ b/lib/src/theme/components/decorator.dart
@@ -357,7 +357,7 @@ class ShadDecorator extends StatelessWidget {
       decorated = CustomPaint(
         foregroundPainter: ShadOutwardBorderPainter(
           border: secondaryBorder.toBorder(),
-          delta: secondaryBorder.offset ?? 0,
+          offset: secondaryBorder.offset ?? 0,
           radius: secondaryBorder.radius?.resolve(textDirection) ??
               BorderRadius.zero,
           textDirection: textDirection,
@@ -377,21 +377,28 @@ class ShadOutwardBorderPainter extends CustomPainter {
   /// {@macro shadOutwardBorderPainter}
   const ShadOutwardBorderPainter({
     required this.border,
-    required this.delta,
+    required this.offset,
     required this.radius,
     required this.textDirection,
   });
 
+  /// The border to paint.
   final Border border;
-  final double delta;
+
+  /// The offset to inflate the border by.
+  final double offset;
+
+  /// The radius of the border.
   final BorderRadius? radius;
+
+  /// The text direction to use when painting the border.
   final TextDirection? textDirection;
 
   @override
   void paint(Canvas canvas, Size size) {
     border.paint(
       canvas,
-      (Offset.zero & size).inflate(delta),
+      (Offset.zero & size).inflate(offset),
       borderRadius: radius,
       textDirection: textDirection,
     );
@@ -400,7 +407,7 @@ class ShadOutwardBorderPainter extends CustomPainter {
   @override
   bool shouldRepaint(covariant ShadOutwardBorderPainter oldDelegate) {
     return border != oldDelegate.border ||
-        delta != oldDelegate.delta ||
+        offset != oldDelegate.offset ||
         radius != oldDelegate.radius ||
         textDirection != oldDelegate.textDirection;
   }

--- a/lib/src/theme/themes/default_theme_variant.dart
+++ b/lib/src/theme/themes/default_theme_variant.dart
@@ -275,14 +275,13 @@ class ShadDefaultThemeVariant extends ShadThemeVariant {
   ShadDecoration decorationTheme() {
     return ShadDecoration(
       secondaryBorder: ShadBorder.all(
-        padding: const EdgeInsets.all(4),
         width: 0,
       ),
       secondaryFocusedBorder: ShadBorder.all(
         width: 2,
         color: colorScheme.ring,
         radius: radius.add(radius / 2),
-        padding: const EdgeInsets.all(2),
+        offset: 4,
       ),
       labelStyle: effectiveTextTheme.muted.copyWith(
         fontWeight: FontWeight.w500,

--- a/lib/src/utils/border.dart
+++ b/lib/src/utils/border.dart
@@ -45,6 +45,7 @@ class ShadBorder {
     this.right,
     this.bottom,
     this.left,
+    this.offset,
   });
 
   /// Creates a border whose sides are all the same.
@@ -53,6 +54,7 @@ class ShadBorder {
     this.merge = true,
     this.padding,
     this.radius,
+    this.offset,
   })  : top = side,
         right = side,
         bottom = side,
@@ -68,6 +70,7 @@ class ShadBorder {
     this.merge = true,
     this.padding,
     this.radius,
+    this.offset,
   })  : left = vertical,
         top = horizontal,
         right = vertical,
@@ -84,6 +87,7 @@ class ShadBorder {
     double? strokeAlign,
     EdgeInsets? padding,
     BorderRadiusGeometry? radius,
+    double? offset,
   }) {
     final side = ShadBorderSide(
       color: color,
@@ -96,6 +100,7 @@ class ShadBorder {
       padding: padding,
       merge: merge,
       radius: radius,
+      offset: offset,
     );
   }
 
@@ -125,6 +130,7 @@ class ShadBorder {
         b?.left,
         t,
       ),
+      offset: lerpDouble(a?.offset, b?.offset, t),
     );
   }
 
@@ -148,6 +154,7 @@ class ShadBorder {
       left: left?.mergeWith(other.left) ?? other.left,
       padding: other.padding,
       radius: other.radius,
+      offset: other.offset,
     );
   }
 
@@ -158,6 +165,7 @@ class ShadBorder {
     ShadBorderSide? bottom,
     ShadBorderSide? left,
     BorderRadiusGeometry? radius,
+    double? offset,
   }) {
     return ShadBorder(
       top: top ?? this.top,
@@ -166,6 +174,7 @@ class ShadBorder {
       left: left ?? this.left,
       padding: padding ?? this.padding,
       radius: radius ?? this.radius,
+      offset: offset ?? this.offset,
     );
   }
 
@@ -178,6 +187,7 @@ class ShadBorder {
   /// The border radius of the border, defaults to null.
   final BorderRadiusGeometry? radius;
 
+  /// The top side of this border.
   final ShadBorderSide? top;
 
   /// The right side of this border.
@@ -188,9 +198,15 @@ class ShadBorder {
   /// The left side of this border.
   final ShadBorderSide? left;
 
+  /// The offset between the border and the widget.
+  ///
+  /// NOTE: This is used only for the secondaryBorder, because the border is
+  /// drawn outward of the widget.
+  final double? offset;
+
   @override
   String toString() {
-    return '''ShadBorder(merge: $merge, padding: $padding, radius: $radius, top: $top, right: $right, bottom: $bottom, left: $left)''';
+    return '''ShadBorder(merge: $merge, padding: $padding, radius: $radius, top: $top, right: $right, bottom: $bottom, left: $left, offset: $offset)''';
   }
 }
 

--- a/lib/src/utils/border.dart
+++ b/lib/src/utils/border.dart
@@ -182,6 +182,8 @@ class ShadBorder {
   final bool merge;
 
   /// The padding of the border, defaults to null.
+  ///
+  /// NOTE: Padding has no effect on secondary borders, use [offset] instead.
   final EdgeInsets? padding;
 
   /// The border radius of the border, defaults to null.
@@ -200,7 +202,7 @@ class ShadBorder {
 
   /// The offset between the border and the widget.
   ///
-  /// NOTE: This is used only for the secondaryBorder, because the border is
+  /// NOTE: This is supported only by the secondaryBorder, because the border is
   /// drawn outward of the widget.
   final double? offset;
 

--- a/lib/src/utils/border.dart
+++ b/lib/src/utils/border.dart
@@ -182,8 +182,6 @@ class ShadBorder {
   final bool merge;
 
   /// The padding of the border, defaults to null.
-  ///
-  /// NOTE: Padding has no effect on secondary borders, use [offset] instead.
   final EdgeInsets? padding;
 
   /// The border radius of the border, defaults to null.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shadcn_ui
 description: shadcn/ui ported in Flutter. Awesome UI components for Flutter, fully customizable.
-version: 0.26.5
+version: 0.27.0
 homepage: https://flutter-shadcn-ui.mariuti.com
 repository: https://github.com/nank1ro/flutter-shadcn-ui
 documentation: https://flutter-shadcn-ui.mariuti.com


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
-->

Implements the new outward secondary border

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making.
- [ ] I followed the [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[Contributor Guide]: [https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview](https://github.com/nank1ro/flutter-shadcn-ui/blob/main/CONTRIBUTING.md)
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Discord]: https://discord.gg/ZhRMAPNh5Y
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to control the distance between the widget and its outward secondary border using an `offset` property.
- **Breaking Changes**
  - The secondary border is now rendered outward from the widget without occupying extra space, affecting all focusable components.
- **Documentation**
  - Updated changelog to reflect the new release and changes.
- **Chores**
  - Updated package version to 0.27.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->