### PR TITLE
Fix(ShadSelect): allow full width expansion inside Expanded/Flexible

### DIFF
--- a/lib/src/components/select.dart
+++ b/lib/src/components/select.dart
@@ -934,25 +934,22 @@ class ShadSelectState<T> extends State<ShadSelect<T>> {
                     FocusScope.of(context).unfocus();
                     popoverController.toggle();
                   },
-                  child: ConstrainedBox(
-                    constraints: effectiveConstraints,
-                    child: Padding(
-                      padding: effectivePadding,
-                      child: Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Flexible(
-                            child: DefaultTextStyle(
-                              style: theme.textTheme.muted.copyWith(
-                                color: theme.colorScheme.foreground,
-                              ),
-                              child: effectiveText,
+                  child: Padding(
+                    padding: effectivePadding,
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Expanded(
+                          child: DefaultTextStyle(
+                            style: theme.textTheme.muted.copyWith(
+                              color: theme.colorScheme.foreground,
                             ),
+                            child: effectiveText,
                           ),
-                          effectiveTrailing,
-                        ],
-                      ),
+                        ),
+                        effectiveTrailing,
+                      ],
                     ),
                   ),
                 ),
@@ -1046,50 +1043,24 @@ class ShadSelectState<T> extends State<ShadSelect<T>> {
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     mainAxisSize: MainAxisSize.min,
                     children: [
-                      if (search != null)
-                        Flexible(
-                          child: ConstrainedBox(
-                            constraints: effectiveConstraints,
-                            child: search,
-                          ),
-                        ),
-                      if (widget.header != null)
-                        Flexible(
-                          child: ConstrainedBox(
-                            constraints: effectiveConstraints,
-                            child: widget.header,
-                          ),
-                        ),
+                      if (search != null) search,
+                      if (widget.header != null) widget.header!,
                       if (scrollToTopChild != null) scrollToTopChild,
-                      Flexible(
-                        child: ConstrainedBox(
-                          constraints: effectiveConstraints,
-                          child: effectiveChild,
-                        ),
-                      ),
+                      effectiveChild,
                       if (scrollToBottomChild != null) scrollToBottomChild,
-                      if (widget.footer != null)
-                        Flexible(
-                          child: ConstrainedBox(
-                            constraints: effectiveConstraints,
-                            child: widget.footer,
-                          ),
-                        ),
+                      if (widget.footer != null) widget.footer!,
                     ],
                   );
 
-                  if (widget.optionsBuilder == null) {
+// Always stretch to max width unless shrinkWrap is explicitly true
+                  if (!(widget.shrinkWrap ?? false)) {
+                    effectiveColumn = SizedBox(
+                        width: double.infinity, child: effectiveColumn);
+                  } else {
                     effectiveColumn = IntrinsicWidth(child: effectiveColumn);
                   }
 
-                  return ConstrainedBox(
-                    constraints: BoxConstraints(
-                      maxHeight: effectiveMaxHeight,
-                      minWidth: calculatedMinWidth,
-                      maxWidth: effectiveMaxWidth,
-                    ),
-                    child: effectiveColumn,
-                  );
+                  return effectiveColumn;
                 },
                 child: select,
               ),


### PR DESCRIPTION
The ShadSelect widget does not stretch to fill the available width when placed inside layout widgets like Expanded or Flexible. Instead, it wraps its content due to the use of IntrinsicWidth, which forces the widget to take only as much space as needed by its content.

This behavior is problematic in responsive layouts or forms where a consistent width across UI elements is expected. As a result, the dropdown appears smaller than desired and doesn't align well with surrounding widgets.

Fixes #374 

Before the PR:

<img width="392" alt="Screenshot 2025-06-09 at 14 39 07" src="https://github.com/user-attachments/assets/37f47e73-ab8f-4ae5-9161-598bcc7172ee" />

After the PR:

<img width="407" alt="Screenshot 2025-06-09 at 14 38 14" src="https://github.com/user-attachments/assets/0ec39a25-a77d-4d1d-a581-ef86b3dcb47c" />
