### PR TITLE
Fix `ShadIconButton` icon size property isn't applied

### DIFF
--- a/lib/src/components/button.dart
+++ b/lib/src/components/button.dart
@@ -924,7 +924,7 @@ class _ShadButtonState extends State<ShadButton> {
   Widget build(BuildContext context) {
     assert(debugCheckHasShadTheme(context));
     final theme = ShadTheme.of(context);
-    final materialTheme = Theme.of(context);
+    final iconTheme = IconTheme.of(context);
 
     final hasPressedBackgroundColor = widget.pressedBackgroundColor != null ||
         buttonTheme(theme).pressedBackgroundColor != null;
@@ -994,7 +994,7 @@ class _ShadButtonState extends State<ShadButton> {
           }
 
           return IconTheme(
-            data: materialTheme.iconTheme.copyWith(
+            data: iconTheme.copyWith(
               color: effectiveForegroundColor,
             ),
             child: DefaultTextStyle(

--- a/test/src/components/icon_button_test.dart
+++ b/test/src/components/icon_button_test.dart
@@ -85,5 +85,20 @@ void main() {
         matchesGoldenFile('goldens/icon_button_ghost.png'),
       );
     });
+
+    testWidgets('ShadIconButton.iconSize updates icon size', (tester) async {
+      const customIconSize = 10.0;
+      await tester.pumpAsyncWidget(
+        createTestWidget(
+          const ShadIconButton(
+            icon: Icon(Icons.add),
+            iconSize: customIconSize,
+          ),
+        ),
+      );
+
+      final iconSize = tester.getSize(find.byType(Icon));
+      expect(iconSize, const Size.square(customIconSize));
+    });    
   });
 }


### PR DESCRIPTION
This fixes an issue where icon size property in `ShadIconButton` or any of its variants isn't applied to the icon. 

This is caused by `ShadButton` not inheriting the updated `IconTheme` in the `ShadIconButton` class when icon size is provided.

### Code Sample

<details>
<summary>expand to view the code sample</summary> 

```dart
import 'package:example/common/base_scaffold.dart';
import 'package:example/common/properties/bool_property.dart';
import 'package:flutter/material.dart';
import 'package:shadcn_ui/shadcn_ui.dart';

class IconButtonPage extends StatefulWidget {
  const IconButtonPage({super.key});

  @override
  State<IconButtonPage> createState() => _IconButtonPageState();
}

class _IconButtonPageState extends State<IconButtonPage> {
  var enabled = true;

  @override
  Widget build(BuildContext context) {
    final theme = ShadTheme.of(context);
    const iconSize = 28.0;
    
    return FocusTraversalGroup(
      policy: WidgetOrderTraversalPolicy(),
      child: BaseScaffold(
        appBarTitle: 'IconButton',
        editable: [
          MyBoolProperty(
            label: 'Enabled',
            value: enabled,
            onChanged: (value) => setState(() => enabled = value),
          ),
        ],
        children: [
          ShadIconButton(
            iconSize: iconSize,
            enabled: enabled,
            onPressed: () => print('Primary'),
            icon: const Icon(LucideIcons.rocket),
          ),
          ShadIconButton.secondary(
            iconSize: iconSize,
            enabled: enabled,
            icon: const Icon(LucideIcons.rocket),
            onPressed: () => print('Secondary'),
          ),
          ShadIconButton.destructive(
            iconSize: iconSize,
            enabled: enabled,
            icon: const Icon(LucideIcons.rocket),
            onPressed: () => print('Destructive'),
          ),
          ShadIconButton.outline(
            iconSize: iconSize,
            enabled: enabled,
            icon: const Icon(LucideIcons.rocket),
            onPressed: () => print('Outline'),
          ),
          ShadIconButton.ghost(
            iconSize: iconSize,
            enabled: enabled,
            icon: const Icon(LucideIcons.rocket),
            onPressed: () => print('Ghost'),
          ),
          ShadIconButton(
            iconSize: iconSize,
            enabled: enabled,
            gradient: const LinearGradient(colors: [
              Colors.cyan,
              Colors.indigo,
            ]),
            shadows: [
              BoxShadow(
                color: Colors.blue.withValues(alpha: .4),
                spreadRadius: 4,
                blurRadius: 10,
                offset: const Offset(0, 2),
              ),
            ],
            icon: const Icon(LucideIcons.rocket),
          ),
          ShadIconButton(
            iconSize: iconSize,
            enabled: enabled,
            icon: SizedBox.square(
              dimension: 16,
              child: CircularProgressIndicator(
                strokeWidth: 2,
                color: theme.colorScheme.primaryForeground,
              ),
            ),
          ),
        ],
      ),
    );
  }
}

```

</details>

### Before (Custom icon size doesn't update button icon size)


<img width="718" alt="Screenshot 2025-06-28 at 21 27 21" src="https://github.com/user-attachments/assets/1f67bb21-bd08-4eed-ae0c-9a7ab9b3a5df" />



### After  (Custom icon size correctly update button icon size)

<img width="718" alt="Screenshot 2025-06-28 at 21 26 18" src="https://github.com/user-attachments/assets/18247c42-d219-42ed-bbe9-541056ba033a" />


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read and followed the [Flutter Style Guide].
- [ x I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making.
- [ ] I followed the [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[Contributor Guide]: [https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview](https://github.com/nank1ro/flutter-shadcn-ui/blob/main/CONTRIBUTING.md)
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Discord]: https://discord.gg/ZhRMAPNh5Y
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved icon theming in buttons to better respect the surrounding icon theme context.

* **Tests**
  * Added a test to verify that custom icon sizes are correctly applied to icon buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->