### PR TITLE
fix: hit test behavior of context menu region

### DIFF
--- a/lib/src/components/context_menu.dart
+++ b/lib/src/components/context_menu.dart
@@ -40,6 +40,7 @@ class ShadContextMenuRegion extends StatefulWidget {
     this.controller,
     this.supportedDevices,
     this.longPressEnabled,
+    this.hitTestBehavior,
   });
 
   /// {@template ShadContextMenuRegion.child}
@@ -79,6 +80,9 @@ class ShadContextMenuRegion extends StatefulWidget {
 
   /// {@macro ShadContextMenu.controller}
   final ShadContextMenuController? controller;
+
+  /// {@macro ShadContextMenu.hitTestBehavior}
+  final HitTestBehavior? hitTestBehavior;
 
   /// The kind of devices that are allowed to be recognized.
   ///
@@ -160,7 +164,7 @@ class _ShadContextMenuRegionState extends State<ShadContextMenuRegion> {
       decoration: widget.decoration,
       filter: widget.filter,
       child: ShadGestureDetector(
-        behavior: HitTestBehavior.opaque,
+        behavior: widget.hitTestBehavior,
         supportedDevices: widget.supportedDevices,
         onTapDown: (_) => hide(),
         onSecondaryTapDown: (d) async {


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
-->

This PR exposes the hit test behaviour of the `ShadContextMenuRegion`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making.
- [x] I followed the [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[Contributor Guide]: [https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview](https://github.com/nank1ro/flutter-shadcn-ui/blob/main/CONTRIBUTING.md)
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Discord]: https://discord.gg/ZhRMAPNh5Y
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to customize touch interaction behavior for context menu regions, allowing greater control over gesture detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->