### PR TITLE
Fix(#397): missing popover closing animation

### DIFF
--- a/lib/src/components/popover.dart
+++ b/lib/src/components/popover.dart
@@ -54,7 +54,6 @@ class ShadPopover extends StatefulWidget {
     this.focusNode,
     this.anchor,
     this.effects,
-    this.duration,
     this.reverseDuration,
     this.shadows,
     this.padding,
@@ -152,17 +151,13 @@ class ShadPopover extends StatefulWidget {
   /// {@endtemplate}
   final bool useSameGroupIdForChild;
 
-  /// {@template ShadPopover.duration}
-  /// The duration of the popover's entrance animation.
-  ///
-  /// Defaults to [Duration(milliseconds: 400)].
-  /// {@endtemplate}
-  final Duration? duration;
-
   /// {@template ShadPopover.reverseDuration}
   /// The duration of the popover's exit animation.
   ///
   /// Defaults to [Duration(milliseconds: 150)].
+  ///
+  /// To customize the opening animation duration,
+  /// use [Effect.duration] in specified [effects].
   /// {@endtemplate}
   final Duration? reverseDuration;
 
@@ -250,12 +245,12 @@ class _ShadPopoverState extends State<ShadPopover>
 
     final theme = ShadTheme.of(context);
 
-    final effectiveDuration = widget.duration ?? theme.popoverTheme.duration;
     final effectiveReverseDuration =
         widget.reverseDuration ?? theme.popoverTheme.reverseDuration;
 
-    // Update the animation controller with the new durations.
-    animationController.duration = effectiveDuration;
+    // The duration will be overridden by the [Animate] widget based on the
+    // animation effects.
+    animationController.duration = Animate.defaultDuration;
     animationController.reverseDuration = effectiveReverseDuration;
 
     effectiveEffects = widget.effects ?? theme.popoverTheme.effects ?? [];

--- a/lib/src/components/popover.dart
+++ b/lib/src/components/popover.dart
@@ -54,6 +54,8 @@ class ShadPopover extends StatefulWidget {
     this.focusNode,
     this.anchor,
     this.effects,
+    this.duration,
+    this.reverseDuration,
     this.shadows,
     this.padding,
     this.decoration,
@@ -150,14 +152,30 @@ class ShadPopover extends StatefulWidget {
   /// {@endtemplate}
   final bool useSameGroupIdForChild;
 
+  /// {@template ShadPopover.duration}
+  /// The duration of the popover's entrance animation.
+  ///
+  /// Defaults to [Animate.defaultDuration].
+  /// {@endtemplate}
+  final Duration? duration;
+
+  /// {@template ShadPopover.reverseDuration}
+  /// The duration of the popover's exit animation.
+  ///
+  /// Defaults to [Duration(milliseconds: 150)].
+  /// {@endtemplate}
+  final Duration? reverseDuration;
+
   @override
   State<ShadPopover> createState() => _ShadPopoverState();
 }
 
-class _ShadPopoverState extends State<ShadPopover> {
+class _ShadPopoverState extends State<ShadPopover>
+    with SingleTickerProviderStateMixin {
   ShadPopoverController? _controller;
   ShadPopoverController get controller => widget.controller ?? _controller!;
-  bool animating = false;
+
+  late final AnimationController animationController;
 
   late final _popoverKey = UniqueKey();
 
@@ -176,12 +194,23 @@ class _ShadPopoverState extends State<ShadPopover> {
     if (widget.controller == null) {
       _controller = ShadPopoverController();
     }
+    animationController = AnimationController(vsync: this);
     controller.addListener(_onPopoverToggle);
+
+    if (controller.isOpen) {
+      animationController.forward(from: 0);
+    }
   }
 
   @override
   void didUpdateWidget(covariant ShadPopover oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (widget.controller != null &&
+        widget.controller != oldWidget.controller) {
+      oldWidget.controller?.removeListener(_onPopoverToggle);
+      widget.controller!.addListener(_onPopoverToggle);
+    }
+
     if (widget.visible != null) {
       if (widget.visible! && !controller.isOpen) {
         controller.show();
@@ -193,18 +222,37 @@ class _ShadPopoverState extends State<ShadPopover> {
 
   @override
   void dispose() {
+    animationController.dispose();
     _popoverFocusNode.dispose();
     _popoverFocusScopeNode.dispose();
     _controller?.dispose();
     super.dispose();
   }
 
-  // When the popover is opened, request focus to be able to receive key
-  // events.
   void _onPopoverToggle() {
     if (controller.isOpen) {
+      animationController.forward(from: 0);
+
+      // When the popover is opened, request focus
+      // to be able to receive key events.
       _popoverFocusNode.requestFocus();
+    } else {
+      animationController.reverse();
     }
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final theme = ShadTheme.of(context);
+
+    final effectiveDuration = widget.duration ?? theme.popoverTheme.duration;
+    final effectiveReverseDuration =
+        widget.reverseDuration ?? theme.popoverTheme.reverseDuration;
+
+    // Update the animation controller with the new durations.
+    animationController.duration = effectiveDuration;
+    animationController.reverseDuration = effectiveReverseDuration;
   }
 
   @override
@@ -261,6 +309,7 @@ class _ShadPopoverState extends State<ShadPopover> {
 
     if (effectiveEffects.isNotEmpty) {
       popover = Animate(
+        controller: animationController,
         effects: effectiveEffects,
         child: popover,
       );
@@ -275,8 +324,8 @@ class _ShadPopoverState extends State<ShadPopover> {
       );
     }
 
-    Widget child = ListenableBuilder(
-      listenable: controller,
+    Widget child = AnimatedBuilder(
+      animation: animationController,
       builder: (context, _) {
         return CallbackShortcuts(
           bindings: {
@@ -296,7 +345,7 @@ class _ShadPopoverState extends State<ShadPopover> {
                 ),
               );
             },
-            visible: controller.isOpen,
+            visible: animationController.isDismissed == false,
             anchor: effectiveAnchor,
             child: widget.child,
           ),

--- a/lib/src/components/popover.dart
+++ b/lib/src/components/popover.dart
@@ -155,7 +155,7 @@ class ShadPopover extends StatefulWidget {
   /// {@template ShadPopover.duration}
   /// The duration of the popover's entrance animation.
   ///
-  /// Defaults to [Animate.defaultDuration].
+  /// Defaults to [Duration(milliseconds: 400)].
   /// {@endtemplate}
   final Duration? duration;
 

--- a/lib/src/components/popover.dart
+++ b/lib/src/components/popover.dart
@@ -183,10 +183,14 @@ class _ShadPopoverState extends State<ShadPopover>
   // It's used to be able to focus the popover and receive key events.
   final _popoverFocusNode = FocusNode();
 
-  // The focus scope node of the popover
-  final _popoverFocusScopeNode = FocusScopeNode();
-
   Object get groupId => widget.groupId ?? _popoverKey;
+
+  late List<Effect<dynamic>> effectiveEffects;
+  late EdgeInsetsGeometry effectivePadding;
+  late List<BoxShadow>? effectiveShadows;
+  late ShadAnchorBase effectiveAnchor;
+  late ImageFilter? effectiveFilter;
+  late ShadDecoration effectiveDecoration;
 
   @override
   void initState() {
@@ -224,7 +228,6 @@ class _ShadPopoverState extends State<ShadPopover>
   void dispose() {
     animationController.dispose();
     _popoverFocusNode.dispose();
-    _popoverFocusScopeNode.dispose();
     _controller?.dispose();
     super.dispose();
   }
@@ -232,9 +235,9 @@ class _ShadPopoverState extends State<ShadPopover>
   void _onPopoverToggle() {
     if (controller.isOpen) {
       animationController.forward(from: 0);
-
       // When the popover is opened, request focus
       // to be able to receive key events.
+
       _popoverFocusNode.requestFocus();
     } else {
       animationController.reverse();
@@ -244,6 +247,7 @@ class _ShadPopoverState extends State<ShadPopover>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
+
     final theme = ShadTheme.of(context);
 
     final effectiveDuration = widget.duration ?? theme.popoverTheme.duration;
@@ -253,18 +257,16 @@ class _ShadPopoverState extends State<ShadPopover>
     // Update the animation controller with the new durations.
     animationController.duration = effectiveDuration;
     animationController.reverseDuration = effectiveReverseDuration;
-  }
 
-  @override
-  Widget build(BuildContext context) {
-    final theme = ShadTheme.of(context);
+    effectiveEffects = widget.effects ?? theme.popoverTheme.effects ?? [];
 
-    final effectiveEffects = widget.effects ?? theme.popoverTheme.effects ?? [];
-    final effectivePadding = widget.padding ??
+    effectivePadding = widget.padding ??
         theme.popoverTheme.padding ??
         const EdgeInsets.symmetric(horizontal: 12, vertical: 6);
+
     final effectiveShadows = widget.shadows ?? theme.popoverTheme.shadows;
-    var effectiveDecoration =
+
+    effectiveDecoration =
         (theme.popoverTheme.decoration ?? const ShadDecoration())
             .mergeWith(widget.decoration)
             .copyWith(shadows: effectiveShadows);
@@ -275,12 +277,15 @@ class _ShadPopoverState extends State<ShadPopover>
       ),
     );
 
-    final effectiveAnchor = widget.anchor ??
+    effectiveAnchor = widget.anchor ??
         theme.popoverTheme.anchor ??
         const ShadAnchorAuto(offset: Offset(0, 4));
 
-    final effectiveFilter = widget.filter ?? theme.popoverTheme.filter;
+    effectiveFilter = widget.filter ?? theme.popoverTheme.filter;
+  }
 
+  @override
+  Widget build(BuildContext context) {
     Widget popover = ShadMouseArea(
       groupId: widget.areaGroupId,
       child: ShadDecorator(
@@ -289,7 +294,7 @@ class _ShadPopoverState extends State<ShadPopover>
           padding: effectivePadding,
           child: DefaultTextStyle(
             style: TextStyle(
-              color: theme.colorScheme.popoverForeground,
+              color: ShadTheme.of(context).colorScheme.popoverForeground,
             ),
             textAlign: TextAlign.center,
             child: Builder(
@@ -337,7 +342,6 @@ class _ShadPopoverState extends State<ShadPopover>
             portalBuilder: (_) {
               // used to trap the focus inside the popover.
               return FocusScope(
-                node: _popoverFocusScopeNode,
                 child: Focus(
                   skipTraversal: true,
                   focusNode: _popoverFocusNode,

--- a/lib/src/components/select.dart
+++ b/lib/src/components/select.dart
@@ -1029,6 +1029,7 @@ class ShadSelectState<T> extends State<ShadSelect<T>> {
                 anchor: effectiveAnchor,
                 closeOnTapOutside: widget.closeOnTapOutside,
                 effects: effectiveEffects,
+                reverseDuration: Duration.zero,
                 shadows: effectiveShadows,
                 filter: effectiveFilter,
                 popover: (_) {

--- a/lib/src/theme/components/popover.dart
+++ b/lib/src/theme/components/popover.dart
@@ -12,7 +12,6 @@ class ShadPopoverTheme {
     this.merge = true,
     this.effects,
     this.shadows,
-    this.duration,
     this.reverseDuration,
     this.padding,
     this.decoration,
@@ -40,9 +39,6 @@ class ShadPopoverTheme {
   /// {@macro ShadPopover.filter}
   final ImageFilter? filter;
 
-  /// {@macro ShadPopover.duration}
-  final Duration? duration;
-
   /// {@macro ShadPopover.reverseDuration}
   final Duration? reverseDuration;
 
@@ -60,9 +56,6 @@ class ShadPopoverTheme {
       decoration: ShadDecoration.lerp(a.decoration, b.decoration, t),
       anchor: t < 0.5 ? a.anchor : b.anchor,
       filter: t < 0.5 ? a.filter : b.filter,
-      duration: a.duration != null && b.duration != null
-          ? lerpDuration(a.duration!, b.duration!, t)
-          : b.duration,
       reverseDuration: a.reverseDuration != null && b.reverseDuration != null
           ? lerpDuration(a.reverseDuration!, b.reverseDuration!, t)
           : b.reverseDuration,
@@ -79,13 +72,11 @@ class ShadPopoverTheme {
     ShadDecoration? decoration,
     ShadAnchorBase? anchor,
     ImageFilter? filter,
-    Duration? duration,
     Duration? reverseDuration,
   }) {
     return ShadPopoverTheme(
       merge: merge ?? this.merge,
       effects: effects ?? this.effects,
-      duration: duration ?? this.duration,
       reverseDuration: reverseDuration ?? this.reverseDuration,
       shadows: shadows ?? this.shadows,
       padding: padding ?? this.padding,
@@ -105,7 +96,6 @@ class ShadPopoverTheme {
       decoration: decoration?.mergeWith(other.decoration) ?? other.decoration,
       anchor: other.anchor,
       filter: other.filter,
-      duration: other.duration,
       reverseDuration: other.reverseDuration,
     );
   }
@@ -122,7 +112,6 @@ class ShadPopoverTheme {
         other.decoration == decoration &&
         other.anchor == anchor &&
         other.filter == filter &&
-        other.duration == duration &&
         other.reverseDuration == reverseDuration;
   }
 
@@ -135,7 +124,6 @@ class ShadPopoverTheme {
         decoration.hashCode ^
         anchor.hashCode ^
         filter.hashCode ^
-        duration.hashCode ^
         reverseDuration.hashCode;
   }
 }

--- a/lib/src/theme/components/popover.dart
+++ b/lib/src/theme/components/popover.dart
@@ -12,6 +12,8 @@ class ShadPopoverTheme {
     this.merge = true,
     this.effects,
     this.shadows,
+    this.duration,
+    this.reverseDuration,
     this.padding,
     this.decoration,
     this.anchor,
@@ -38,6 +40,12 @@ class ShadPopoverTheme {
   /// {@macro popover.filter}
   final ImageFilter? filter;
 
+  /// {@macro ShadPopover.duration}
+  final Duration? duration;
+
+  /// {@macro ShadPopover.reverseDuration}
+  final Duration? reverseDuration;
+
   static ShadPopoverTheme lerp(
     ShadPopoverTheme a,
     ShadPopoverTheme b,
@@ -52,6 +60,12 @@ class ShadPopoverTheme {
       decoration: ShadDecoration.lerp(a.decoration, b.decoration, t),
       anchor: t < 0.5 ? a.anchor : b.anchor,
       filter: t < 0.5 ? a.filter : b.filter,
+      duration: a.duration != null && b.duration != null
+          ? lerpDuration(a.duration!, b.duration!, t)
+          : b.duration,
+      reverseDuration: a.reverseDuration != null && b.reverseDuration != null
+          ? lerpDuration(a.reverseDuration!, b.reverseDuration!, t)
+          : b.reverseDuration,
     );
   }
 
@@ -65,10 +79,14 @@ class ShadPopoverTheme {
     ShadDecoration? decoration,
     ShadAnchorBase? anchor,
     ImageFilter? filter,
+    Duration? duration,
+    Duration? reverseDuration,
   }) {
     return ShadPopoverTheme(
       merge: merge ?? this.merge,
       effects: effects ?? this.effects,
+      duration: duration ?? this.duration,
+      reverseDuration: reverseDuration ?? this.reverseDuration,
       shadows: shadows ?? this.shadows,
       padding: padding ?? this.padding,
       decoration: decoration ?? this.decoration,
@@ -87,6 +105,8 @@ class ShadPopoverTheme {
       decoration: decoration?.mergeWith(other.decoration) ?? other.decoration,
       anchor: other.anchor,
       filter: other.filter,
+      duration: other.duration,
+      reverseDuration: other.reverseDuration,
     );
   }
 
@@ -101,7 +121,9 @@ class ShadPopoverTheme {
         other.padding == padding &&
         other.decoration == decoration &&
         other.anchor == anchor &&
-        other.filter == filter;
+        other.filter == filter &&
+        other.duration == duration &&
+        other.reverseDuration == reverseDuration;
   }
 
   @override
@@ -112,6 +134,8 @@ class ShadPopoverTheme {
         padding.hashCode ^
         decoration.hashCode ^
         anchor.hashCode ^
-        filter.hashCode;
+        filter.hashCode ^
+        duration.hashCode ^
+        reverseDuration.hashCode;
   }
 }

--- a/lib/src/theme/components/popover.dart
+++ b/lib/src/theme/components/popover.dart
@@ -22,22 +22,22 @@ class ShadPopoverTheme {
 
   final bool merge;
 
-  /// {@macro popover.effects}
+  /// {@macro ShadPopover.effects}
   final List<Effect<dynamic>>? effects;
 
-  /// {@macro popover.shadows}
+  /// {@macro ShadPopover.shadows}
   final List<BoxShadow>? shadows;
 
-  /// {@macro popover.padding}
+  /// {@macro ShadPopover.padding}
   final EdgeInsetsGeometry? padding;
 
-  /// {@macro popover.decoration}
+  /// {@macro ShadPopover.decoration}
   final ShadDecoration? decoration;
 
-  /// {@macro popover.anchor}
+  /// {@macro ShadPopover.anchor}
   final ShadAnchorBase? anchor;
 
-  /// {@macro popover.filter}
+  /// {@macro ShadPopover.filter}
   final ImageFilter? filter;
 
   /// {@macro ShadPopover.duration}

--- a/lib/src/theme/themes/default_theme_no_secondary_border_variant.dart
+++ b/lib/src/theme/themes/default_theme_no_secondary_border_variant.dart
@@ -277,7 +277,7 @@ class ShadDefaultThemeNoSecondaryBorderVariant extends ShadThemeVariant {
           duration: Duration(milliseconds: 100),
         ),
       ],
-      duration: Animate.defaultDuration,
+      duration: const Duration(milliseconds: 400),
       reverseDuration: const Duration(milliseconds: 150),
       shadows: ShadShadows.md,
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),

--- a/lib/src/theme/themes/default_theme_no_secondary_border_variant.dart
+++ b/lib/src/theme/themes/default_theme_no_secondary_border_variant.dart
@@ -265,19 +265,18 @@ class ShadDefaultThemeNoSecondaryBorderVariant extends ShadThemeVariant {
   ShadPopoverTheme popoverTheme() {
     return ShadPopoverTheme(
       effects: const [
-        FadeEffect(duration: Duration(milliseconds: 100)),
+        FadeEffect(duration: Duration(milliseconds: 150)),
         ScaleEffect(
           begin: Offset(.95, .95),
           end: Offset(1, 1),
-          duration: Duration(milliseconds: 100),
+          duration: Duration(milliseconds: 150),
         ),
         MoveEffect(
           begin: Offset(0, 2),
           end: Offset.zero,
-          duration: Duration(milliseconds: 100),
+          duration: Duration(milliseconds: 150),
         ),
       ],
-      duration: const Duration(milliseconds: 400),
       reverseDuration: const Duration(milliseconds: 150),
       shadows: ShadShadows.md,
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),

--- a/lib/src/theme/themes/default_theme_no_secondary_border_variant.dart
+++ b/lib/src/theme/themes/default_theme_no_secondary_border_variant.dart
@@ -277,6 +277,8 @@ class ShadDefaultThemeNoSecondaryBorderVariant extends ShadThemeVariant {
           duration: Duration(milliseconds: 100),
         ),
       ],
+      duration: Animate.defaultDuration,
+      reverseDuration: const Duration(milliseconds: 150),
       shadows: ShadShadows.md,
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
       decoration: ShadDecoration(

--- a/lib/src/theme/themes/default_theme_variant.dart
+++ b/lib/src/theme/themes/default_theme_variant.dart
@@ -245,7 +245,9 @@ class ShadDefaultThemeVariant extends ShadThemeVariant {
   ShadPopoverTheme popoverTheme() {
     return ShadPopoverTheme(
       effects: const [
-        FadeEffect(duration: Duration(milliseconds: 100)),
+        FadeEffect(
+          duration: Duration(milliseconds: 100),
+        ),
         ScaleEffect(
           begin: Offset(.95, .95),
           end: Offset(1, 1),
@@ -257,6 +259,8 @@ class ShadDefaultThemeVariant extends ShadThemeVariant {
           duration: Duration(milliseconds: 100),
         ),
       ],
+      duration: Animate.defaultDuration,
+      reverseDuration: const Duration(milliseconds: 150),
       shadows: ShadShadows.md,
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
       decoration: ShadDecoration(

--- a/lib/src/theme/themes/default_theme_variant.dart
+++ b/lib/src/theme/themes/default_theme_variant.dart
@@ -259,7 +259,7 @@ class ShadDefaultThemeVariant extends ShadThemeVariant {
           duration: Duration(milliseconds: 100),
         ),
       ],
-      duration: Animate.defaultDuration,
+      duration: const Duration(milliseconds: 400),
       reverseDuration: const Duration(milliseconds: 150),
       shadows: ShadShadows.md,
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),

--- a/lib/src/theme/themes/default_theme_variant.dart
+++ b/lib/src/theme/themes/default_theme_variant.dart
@@ -246,20 +246,19 @@ class ShadDefaultThemeVariant extends ShadThemeVariant {
     return ShadPopoverTheme(
       effects: const [
         FadeEffect(
-          duration: Duration(milliseconds: 100),
+          duration: Duration(milliseconds: 150),
         ),
         ScaleEffect(
           begin: Offset(.95, .95),
           end: Offset(1, 1),
-          duration: Duration(milliseconds: 100),
+          duration: Duration(milliseconds: 150),
         ),
         MoveEffect(
           begin: Offset(0, 2),
           end: Offset.zero,
-          duration: Duration(milliseconds: 100),
+          duration: Duration(milliseconds: 150),
         ),
       ],
-      duration: const Duration(milliseconds: 400),
       reverseDuration: const Duration(milliseconds: 150),
       shadows: ShadShadows.md,
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),


### PR DESCRIPTION
## Purpose

- resolve #397 

## Changes

- Added a custom `AnimationController` to drive the opening and closing animations of the popover.
- Used an `AnimatedBuilder` to keep the popover in the widget tree until the closing animation is finished.
- Added `reverseDuration` field to `ShadPopover` and `ShadPopoverTheme`.
- Set the reverseDuration of the popover used in `ShadSelect` to `Duration.zero` based on original Shadcn UI compoenent.  

### Recodreings

## Notes

- Should we allow customization for the `ShadPopover.reverseDuration` from the: `ShadSelect`,  `ShadContextMenu`, `ShadDatePicker`?
- I originally added a duration field to the popover component and theme but turns out it gets overridden, see last commit.
- Thank u for time.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making.
- [x] I followed the [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.