### PR TITLE
fix: updated `ShadPopover` filter logic to use effectiveFilter instead of widget.filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.28.7
+
+- **FIX**: Updated `ShadPopover` filter logic to use effectiveFilter instead of widget.filter.
+
 ## 0.28.6
 
 - **REFACTOR**: Add `cursor*` customizations through theme (thanks to @GuillaumeMCK).

--- a/lib/src/components/popover.dart
+++ b/lib/src/components/popover.dart
@@ -254,7 +254,7 @@ class _ShadPopoverState extends State<ShadPopover> {
 
     if (effectiveFilter != null) {
       popover = BackdropFilter(
-        filter: widget.filter!,
+        filter: effectiveFilter,
         child: popover,
       );
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shadcn_ui
 description: shadcn/ui ported in Flutter. Awesome UI components for Flutter, fully customizable.
-version: 0.28.6
+version: 0.28.7
 homepage: https://flutter-shadcn-ui.mariuti.com
 repository: https://github.com/nank1ro/flutter-shadcn-ui
 documentation: https://flutter-shadcn-ui.mariuti.com


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
-->

Fixes a null check issue that occurs when the `filter` argument is provided from `ShadPopoverTheme`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making.
- [x] I followed the [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
- [x] I bumped the package version following the [Semantic Versioning](https://semver.org/) guidelines (For now the major is the second number and the minor the third, because the package is not feature complete). For example, if the package is at version `0.18.0` and you introduced a breaking change or a new feature, bump it to `0.19.0`, if you just added a fix or a chore bump it to `0.18.1`.
- [x] I updated the `CHANGELOG.md` file with a summary of changes made following the format already used.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[Contributor Guide]: [https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview](https://github.com/nank1ro/flutter-shadcn-ui/blob/main/CONTRIBUTING.md)
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Discord]: https://discord.gg/ZhRMAPNh5Y
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
