### PR TITLE
fix: form onChanged callback not firing and missing forceErrorText field [#427]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ lcov.info
 .firebase
 .fvmrc
 .supermaven
+
+# Ignore golden test files
+test/**/*.png

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.29.3
+
+- **FIX**: Ensure `ShadForm.onChanged` handler is called for standard Form fields as well as Shad-FormField's.
+- **FIX**: Add missing `forceErrorText` field to ShadFormField's.
+
 ## 0.29.2
 
 - **FIX**: Fix `ShadResizable` on RTL. Remove useless `textDirection` parameter from `ShadResizable` and `ShadResizableTheme`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.29.3
 
 - **FIX**: Ensure `ShadForm.onChanged` is called for both standard `Form` fields and `ShadFormField` widgets.
-- **FIX**: Add missing `forceErrorText` field to ShadFormField's.
+- **FIX**: Add missing `forceErrorText` parameter to `ShadFormField` widgets.
 
 ## 0.29.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.29.3
 
-- **FIX**: Ensure `ShadForm.onChanged` handler is called for standard Form fields as well as Shad-FormField's.
+- **FIX**: Ensure `ShadForm.onChanged` is called for both standard `Form` fields and `ShadFormField` widgets.
 - **FIX**: Add missing `forceErrorText` field to ShadFormField's.
 
 ## 0.29.2

--- a/lib/src/components/form/field.dart
+++ b/lib/src/components/form/field.dart
@@ -24,6 +24,7 @@ class ShadFormBuilderField<T> extends FormField<T> {
     super.key,
     required Widget Function(FormFieldState<T>) builder,
     super.onSaved,
+    super.forceErrorText,
     super.validator,
     super.initialValue,
     super.enabled,

--- a/lib/src/components/form/fields/checkbox.dart
+++ b/lib/src/components/form/fields/checkbox.dart
@@ -9,6 +9,7 @@ class ShadCheckboxFormField extends ShadFormBuilderField<bool> {
     super.id,
     super.key,
     super.onSaved,
+    super.forceErrorText,
     super.label,
     super.error,
     super.description,

--- a/lib/src/components/form/fields/date_picker.dart
+++ b/lib/src/components/form/fields/date_picker.dart
@@ -18,6 +18,7 @@ class ShadDatePickerFormField extends ShadFormBuilderField<DateTime> {
     super.id,
     super.key,
     super.onSaved,
+    super.forceErrorText,
     super.label,
     super.error,
     super.description,

--- a/lib/src/components/form/fields/date_range_picker.dart
+++ b/lib/src/components/form/fields/date_range_picker.dart
@@ -19,6 +19,7 @@ class ShadDateRangePickerFormField
     super.id,
     super.key,
     super.onSaved,
+    super.forceErrorText,
     super.label,
     super.error,
     super.description,

--- a/lib/src/components/form/fields/input.dart
+++ b/lib/src/components/form/fields/input.dart
@@ -13,6 +13,7 @@ class ShadInputFormField extends ShadFormBuilderField<String> {
     super.id,
     super.key,
     super.onSaved,
+    super.forceErrorText,
     String? Function(String)? validator,
     String? initialValue,
     super.enabled,

--- a/lib/src/components/form/fields/input_otp.dart
+++ b/lib/src/components/form/fields/input_otp.dart
@@ -8,6 +8,7 @@ class ShadInputOTPFormField extends ShadFormBuilderField<String> {
     super.id,
     super.key,
     super.onSaved,
+    super.forceErrorText,
 
     /// {@macro ShadFormBuilderField.validator}
     String? Function(String)? validator,

--- a/lib/src/components/form/fields/radio.dart
+++ b/lib/src/components/form/fields/radio.dart
@@ -9,6 +9,7 @@ class ShadRadioGroupFormField<T> extends ShadFormBuilderField<T> {
     super.id,
     super.key,
     super.onSaved,
+    super.forceErrorText,
     super.label,
     super.error,
     super.description,

--- a/lib/src/components/form/fields/select.dart
+++ b/lib/src/components/form/fields/select.dart
@@ -13,6 +13,7 @@ class ShadSelectFormField<T> extends ShadFormBuilderField<T> {
     super.id,
     super.key,
     super.onSaved,
+    super.forceErrorText,
     super.label,
     super.error,
     super.description,

--- a/lib/src/components/form/fields/switch.dart
+++ b/lib/src/components/form/fields/switch.dart
@@ -9,6 +9,7 @@ class ShadSwitchFormField extends ShadFormBuilderField<bool> {
     super.id,
     super.key,
     super.onSaved,
+    super.forceErrorText,
     super.label,
     super.error,
     super.description,

--- a/lib/src/components/form/fields/textarea.dart
+++ b/lib/src/components/form/fields/textarea.dart
@@ -12,6 +12,7 @@ class ShadTextareaFormField extends ShadFormBuilderField<String> {
     super.key,
     super.id,
     super.onSaved,
+    super.forceErrorText,
     String? Function(String)? validator,
     String? initialValue,
     super.enabled,

--- a/lib/src/components/form/fields/time_picker.dart
+++ b/lib/src/components/form/fields/time_picker.dart
@@ -8,6 +8,7 @@ class ShadTimePickerFormField extends ShadFormBuilderField<ShadTimeOfDay> {
     super.id,
     super.key,
     super.onSaved,
+    super.forceErrorText,
     super.label,
     super.error,
     super.description,

--- a/lib/src/components/form/form.dart
+++ b/lib/src/components/form/form.dart
@@ -152,7 +152,6 @@ class ShadFormState extends State<ShadForm> {
 
   void setInternalFieldValue<T>(Object id, T? value) {
     _value[id] = value;
-    widget.onChanged?.call();
   }
 
   /// Removes internal field value
@@ -239,6 +238,7 @@ class ShadFormState extends State<ShadForm> {
           onPopInvoked: widget.onPopInvoked,
           onPopInvokedWithResult: widget.onPopInvokedWithResult,
           canPop: widget.canPop,
+          onChanged: widget.onChanged,
           child: child!,
         );
       },

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shadcn_ui
 description: shadcn/ui ported in Flutter. Awesome UI components for Flutter, fully customizable.
-version: 0.29.2
+version: 0.29.3
 homepage: https://flutter-shadcn-ui.mariuti.com
 repository: https://github.com/nank1ro/flutter-shadcn-ui
 documentation: https://flutter-shadcn-ui.mariuti.com


### PR DESCRIPTION
1. onChanged on a ShadForm is not called when form fields are changed.
2. Missing forceErrorText from *FormField widget definitions.

This PR resolves these two issues.

Resolves #427

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making.
- [ ] I followed the [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.
- [ ] I bumped the package version following the [Semantic Versioning](https://semver.org/) guidelines (For now the major is the second number and the minor the third, because the package is not feature complete). For example, if the package is at version `0.18.0` and you introduced a breaking change or a new feature, bump it to `0.19.0`, if you just added a fix or a chore bump it to `0.18.1`.
- [ ] I updated the `CHANGELOG.md` file with a summary of changes made following the format already used.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[Contributor Guide]: [https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview](https://github.com/nank1ro/flutter-shadcn-ui/blob/main/CONTRIBUTING.md)
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Discord]: https://discord.gg/ZhRMAPNh5Y
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Many form fields now accept a force-display error option to explicitly show custom error text (input, textarea, checkbox, switch, radio, select, OTP, date/time, and date-range pickers).
* **Bug Fixes / Improvements**
  * Forms now correctly propagate onChanged events from standard Form fields so external onChanged callbacks fire when fields update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->