### PR TITLE
fix: 435 input and textarea on changed fired twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.30.3
+
+- **FIX**: `onChanged` of `ShadInputFormField` and `ShadTextareaFormField` fired twice for any change.
+
 ## 0.30.2
 
 - **FIX**: Expose `ShadDefaultKeyboardToolbarTheme`.

--- a/lib/src/components/form/fields/input.dart
+++ b/lib/src/components/form/fields/input.dart
@@ -265,7 +265,6 @@ class ShadInputFormField extends ShadFormBuilderField<String> {
               maxLines: maxLines,
               minLines: minLines,
               expands: expands,
-              onChanged: onChanged,
               onEditingComplete: onEditingComplete,
               onSubmitted: onSubmitted,
               onAppPrivateCommand: onAppPrivateCommand,

--- a/lib/src/components/form/fields/textarea.dart
+++ b/lib/src/components/form/fields/textarea.dart
@@ -226,7 +226,6 @@ class ShadTextareaFormField extends ShadFormBuilderField<String> {
               constraints: constraints,
               mainAxisAlignment: mainAxisAlignment,
               crossAxisAlignment: crossAxisAlignment,
-              onChanged: onChanged,
               onEditingComplete: onEditingComplete,
               onSubmitted: onSubmitted,
               onAppPrivateCommand: onAppPrivateCommand,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shadcn_ui
 description: shadcn/ui ported in Flutter. Awesome UI components for Flutter, fully customizable.
-version: 0.30.2
+version: 0.30.3
 homepage: https://flutter-shadcn-ui.mariuti.com
 repository: https://github.com/nank1ro/flutter-shadcn-ui
 documentation: https://flutter-shadcn-ui.mariuti.com


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
-->

closes #435 

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making.
- [ ] I followed the [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.
- [ ] I bumped the package version following the [Semantic Versioning](https://semver.org/) guidelines (For now the major is the second number and the minor the third, because the package is not feature complete). For example, if the package is at version `0.18.0` and you introduced a breaking change or a new feature, bump it to `0.19.0`, if you just added a fix or a chore bump it to `0.18.1`.
- [ ] I updated the `CHANGELOG.md` file with a summary of changes made following the format already used.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[Contributor Guide]: [https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview](https://github.com/nank1ro/flutter-shadcn-ui/blob/main/CONTRIBUTING.md)
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Discord]: https://discord.gg/ZhRMAPNh5Y
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
