### PR TITLE
fix: 472 select ensure visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.33.1
+
+- **FIX**: `ShadSelect` always scrolling to the selected option when opening the popover which can now be disabled with `ensureSelectedVisible: false`.
+- **CHORE**: Remove `required` from `onSearchChanged` in `ShadSelect` and `ShadSelectFormField` to make it optional, as it is not required when a custom `search` widget is provided.
+
 ## 0.33.0
 
 - **FEAT**: Allow extending `ShadTextTheme` with custom text styles through the `custom` parameter. [See docs](https://flutter-shadcn-ui.mariuti.com/typography#extend-with-custom-styles).

--- a/example/lib/pages/select.dart
+++ b/example/lib/pages/select.dart
@@ -74,6 +74,8 @@ class _SelectPageState extends State<SelectPage> {
   final focusNodes = [FocusNode(), FocusNode(), FocusNode(), FocusNode()];
   var searchValue = '';
   bool allowDeselection = false;
+  bool closeOnSelect = true;
+  bool ensureSelectedVisible = true;
 
   Map<String, String> get filteredFrameworks => {
         for (final framework in frameworks.entries)
@@ -129,15 +131,27 @@ class _SelectPageState extends State<SelectPage> {
           value: allowDeselection,
           onChanged: (value) => setState(() => allowDeselection = value),
         ),
+        MyBoolProperty(
+          label: 'Close on select',
+          value: closeOnSelect,
+          onChanged: (value) => setState(() => closeOnSelect = value),
+        ),
+        MyBoolProperty(
+          label: 'Ensure selected visible',
+          value: ensureSelectedVisible,
+          onChanged: (value) => setState(() => ensureSelectedVisible = value),
+        ),
       ],
       children: [
         ShadSelect<String>(
           minWidth: 180,
           onChanged: print,
+          closeOnSelect: closeOnSelect,
           enabled: enabled,
           focusNode: focusNodes[0],
           placeholder: const Text('Select a fruit'),
           allowDeselection: allowDeselection,
+          ensureSelectedVisible: ensureSelectedVisible,
           options: [
             Padding(
               padding: const EdgeInsets.fromLTRB(32, 6, 6, 6),
@@ -161,7 +175,9 @@ class _SelectPageState extends State<SelectPage> {
           focusNode: focusNodes[1],
           onChanged: print,
           enabled: enabled,
+          closeOnSelect: closeOnSelect,
           placeholder: const Text('Select a timezone'),
+          ensureSelectedVisible: ensureSelectedVisible,
           options: timezones.entries.map(
             (zone) => Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -201,7 +217,9 @@ class _SelectPageState extends State<SelectPage> {
           maxWidth: 300,
           placeholder: const Text('Select framework...'),
           onSearchChanged: (value) => setState(() => searchValue = value),
+          closeOnSelect: closeOnSelect,
           searchPlaceholder: const Text('Search framework'),
+          ensureSelectedVisible: ensureSelectedVisible,
           options: [
             if (filteredFrameworks.isEmpty)
               const Padding(
@@ -233,7 +251,8 @@ class _SelectPageState extends State<SelectPage> {
           focusNode: focusNodes[3],
           allowDeselection: allowDeselection,
           placeholder: const Text('Select multiple fruits'),
-          closeOnSelect: false,
+          closeOnSelect: closeOnSelect,
+          ensureSelectedVisible: ensureSelectedVisible,
           options: [
             Padding(
               padding: const EdgeInsets.fromLTRB(32, 6, 6, 6),

--- a/lib/src/components/form/fields/select.dart
+++ b/lib/src/components/form/fields/select.dart
@@ -102,6 +102,9 @@ class ShadSelectFormField<T> extends ShadFormBuilderField<T> {
     /// {@macro ShadSelect.shrinkWrap}
     bool? shrinkWrap,
     this.controller,
+
+    /// {@macro ShadSelect.ensureSelectedVisible}
+    bool? ensureSelectedVisible,
   }) : super(
           decorationBuilder: (context) =>
               (ShadTheme.of(context).selectTheme.decoration ??
@@ -141,6 +144,7 @@ class ShadSelectFormField<T> extends ShadFormBuilderField<T> {
               itemCount: itemCount,
               shrinkWrap: shrinkWrap,
               controller: state.controller,
+              ensureSelectedVisible: ensureSelectedVisible,
             );
           },
         );
@@ -166,7 +170,7 @@ class ShadSelectFormField<T> extends ShadFormBuilderField<T> {
 
     /// The builder for the options of the [ShadSelect].
     Widget? Function(BuildContext, int)? optionsBuilder,
-    required ValueChanged<String> onSearchChanged,
+    ValueChanged<String>? onSearchChanged,
     Widget? placeholder,
     bool closeOnTapOutside = true,
     double? minWidth,
@@ -208,6 +212,9 @@ class ShadSelectFormField<T> extends ShadFormBuilderField<T> {
 
     /// {@macro ShadSelect.controller}
     this.controller,
+
+    /// {@macro ShadSelect.ensureSelectedVisible}
+    bool? ensureSelectedVisible,
   }) : super(
           decorationBuilder: (context) =>
               (ShadTheme.of(context).selectTheme.decoration ??
@@ -254,6 +261,7 @@ class ShadSelectFormField<T> extends ShadFormBuilderField<T> {
               itemCount: itemCount,
               shrinkWrap: shrinkWrap,
               controller: state.controller,
+              ensureSelectedVisible: ensureSelectedVisible,
             );
           },
         );
@@ -321,11 +329,10 @@ class ShadSelectFormField<T> extends ShadFormBuilderField<T> {
 
     /// {@macro ShadSelect.controller}
     this.controller,
+
+    /// {@macro ShadSelect.ensureSelectedVisible}
+    bool? ensureSelectedVisible,
   })  : assert(
-          variant == ShadSelectVariant.primary || onSearchChanged != null,
-          'onSearchChanged must be provided when variant is search',
-        ),
-        assert(
           variant == ShadSelectVariant.primary ||
               variant == ShadSelectVariant.search,
           '''The variant is not supported. Use primary or search or use ShadSelectMultipleFormField instead.''',
@@ -376,6 +383,7 @@ class ShadSelectFormField<T> extends ShadFormBuilderField<T> {
               itemCount: itemCount,
               shrinkWrap: shrinkWrap,
               controller: state.controller,
+              ensureSelectedVisible: ensureSelectedVisible,
             );
           },
         );
@@ -469,6 +477,9 @@ class ShadSelectMultipleFormField<T> extends ShadFormBuilderField<Set<T>> {
     /// {@macro ShadSelect.allowDeselection}
     bool allowDeselection = true,
     this.controller,
+
+    /// {@macro ShadSelect.ensureSelectedVisible}
+    bool? ensureSelectedVisible,
   }) : super(
           decorationBuilder: (context) =>
               (ShadTheme.of(context).selectTheme.decoration ??
@@ -505,6 +516,7 @@ class ShadSelectMultipleFormField<T> extends ShadFormBuilderField<Set<T>> {
               closeOnSelect: closeOnSelect,
               allowDeselection: allowDeselection,
               controller: state.controller,
+              ensureSelectedVisible: ensureSelectedVisible,
             );
           },
         );
@@ -530,7 +542,7 @@ class ShadSelectMultipleFormField<T> extends ShadFormBuilderField<Set<T>> {
 
     /// The builder for the options of the [ShadSelect].
     Widget? Function(BuildContext, int)? optionsBuilder,
-    required ValueChanged<String> onSearchChanged,
+    ValueChanged<String>? onSearchChanged,
     Widget? placeholder,
     bool closeOnTapOutside = true,
     double? minWidth,
@@ -563,6 +575,9 @@ class ShadSelectMultipleFormField<T> extends ShadFormBuilderField<Set<T>> {
     /// {@macro ShadSelect.allowDeselection}
     bool allowDeselection = true,
     this.controller,
+
+    /// {@macro ShadSelect.ensureSelectedVisible}
+    bool? ensureSelectedVisible,
   }) : super(
           decorationBuilder: (context) =>
               (ShadTheme.of(context).selectTheme.decoration ??
@@ -606,6 +621,7 @@ class ShadSelectMultipleFormField<T> extends ShadFormBuilderField<Set<T>> {
               closeOnSelect: closeOnSelect,
               allowDeselection: allowDeselection,
               controller: state.controller,
+              ensureSelectedVisible: ensureSelectedVisible,
             );
           },
         );
@@ -662,6 +678,9 @@ class ShadSelectMultipleFormField<T> extends ShadFormBuilderField<Set<T>> {
     bool allowDeselection = true,
     bool closeOnSelect = true,
     this.controller,
+
+    /// {@macro ShadSelect.ensureSelectedVisible}
+    bool? ensureSelectedVisible,
   })  : assert(
           variant == ShadSelectVariant.multiple ||
               variant == ShadSelectVariant.multipleWithSearch,
@@ -710,6 +729,7 @@ class ShadSelectMultipleFormField<T> extends ShadFormBuilderField<Set<T>> {
               allowDeselection: allowDeselection,
               closeOnSelect: closeOnSelect,
               controller: state.controller,
+              ensureSelectedVisible: ensureSelectedVisible,
             );
           },
         );

--- a/lib/src/components/select.dart
+++ b/lib/src/components/select.dart
@@ -1204,18 +1204,17 @@ class _ShadOptionState<T> extends State<ShadOption<T>> {
     final inherited =
         context.read<ShadSelectState<dynamic>>() as ShadSelectState<T>;
     final selected = inherited.controller.value.contains(widget.value);
-    if (selected) focusNode.requestFocus();
-
-    print(
-        'inherited.ensureSelectedVisible: ${inherited.ensureSelectedVisible}');
-    if (selected && inherited.ensureSelectedVisible == true) {
-      // scroll to the selected option
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (!mounted) return;
-        Scrollable.maybeOf(context)
-            ?.position
-            .ensureVisible(context.findRenderObject()!);
-      });
+    if (selected) {
+      focusNode.requestFocus();
+      if (inherited.ensureSelectedVisible == true) {
+        // scroll to the selected option
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted) return;
+          Scrollable.maybeOf(context)
+              ?.position
+              .ensureVisible(context.findRenderObject()!);
+        });
+      }
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shadcn_ui
 description: shadcn/ui ported in Flutter. Awesome UI components for Flutter, fully customizable.
-version: 0.33.0
+version: 0.33.1
 homepage: https://flutter-shadcn-ui.mariuti.com
 repository: https://github.com/nank1ro/flutter-shadcn-ui
 documentation: https://flutter-shadcn-ui.mariuti.com


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
-->

closes #472 

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making.
- [ ] I followed the [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.
- [ ] I bumped the package version following the [Semantic Versioning](https://semver.org/) guidelines (For now the major is the second number and the minor the third, because the package is not feature complete). For example, if the package is at version `0.18.0` and you introduced a breaking change or a new feature, bump it to `0.19.0`, if you just added a fix or a chore bump it to `0.18.1`.
- [ ] I updated the `CHANGELOG.md` file with a summary of changes made following the format already used.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[Contributor Guide]: [https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview](https://github.com/nank1ro/flutter-shadcn-ui/blob/main/CONTRIBUTING.md)
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Discord]: https://discord.gg/ZhRMAPNh5Y
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added ensureSelectedVisible parameter to all ShadSelect variants and related form fields to control auto-scrolling to the selected option.

- Bug Fixes
  - You can now disable automatic scrolling to the selected option by setting ensureSelectedVisible to false.

- Chores
  - onSearchChanged is now optional in ShadSelect and ShadSelectFormField variants with search.
  - Version bumped to 0.33.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->