### PR TITLE
Fix: `ShadOption.selectedIcon` is always visible

### DIFF
--- a/lib/src/components/select.dart
+++ b/lib/src/components/select.dart
@@ -1249,10 +1249,10 @@ class _ShadOptionState<T> extends State<ShadOption<T>> {
     final effectiveRadius =
         widget.radius ?? theme.optionTheme.radius ?? theme.radius;
 
-    final effectiveSelectedIcon = widget.selectedIcon ??
-        Visibility.maintain(
-          visible: selected,
-          child: Padding(
+    final effectiveSelectedIcon = Visibility.maintain(
+      visible: selected,
+      child: widget.selectedIcon ??
+          Padding(
             padding: const EdgeInsets.only(right: 8),
             child: Icon(
               LucideIcons.check,
@@ -1260,7 +1260,7 @@ class _ShadOptionState<T> extends State<ShadOption<T>> {
               color: theme.colorScheme.popoverForeground,
             ),
           ),
-        );
+    );
 
     return CallbackShortcuts(
       bindings: {


### PR DESCRIPTION
Fix #484 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read and followed the [Flutter Style Guide].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making.
- [x] I followed the [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
- [ ] I bumped the package version following the [Semantic Versioning](https://semver.org/) guidelines (For now the major is the second number and the minor the third, because the package is not feature complete). For example, if the package is at version `0.18.0` and you introduced a breaking change or a new feature, bump it to `0.19.0`, if you just added a fix or a chore bump it to `0.18.1`.
- [ ] I updated the `CHANGELOG.md` file with a summary of changes made following the format already used.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[Contributor Guide]: [https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview](https://github.com/nank1ro/flutter-shadcn-ui/blob/main/CONTRIBUTING.md)
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Discord]: https://discord.gg/ZhRMAPNh5Y
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md
