### PR TITLE
refactor(dialog-route): improve naming

### DIFF
--- a/lib/src/components/dialog.dart
+++ b/lib/src/components/dialog.dart
@@ -141,16 +141,17 @@ Future<T?> showShadDialog<T>({
         ScaleEffect(begin: Offset(1, 1), end: Offset(.95, .95)),
       ];
 
-  /// Calculates the total duration of a list of [Effect]s.
-  Duration getEffectsDuration(List<Effect<dynamic>> effects) {
+  /// Returns the maximum duration(including delay) from
+  /// the list of [Effect]s.
+  Duration maxCompletionDuration(List<Effect<dynamic>> effects) {
     if (effects.isEmpty) return Duration.zero;
 
     return effects.fold<Duration>(
       Duration.zero, // start with zero
       (max, effect) {
-        final total = (effect.delay ?? Duration.zero) +
+        final effectTotal = (effect.delay ?? Duration.zero) +
             (effect.duration ?? Animate.defaultDuration);
-        return total > max ? total : max;
+        return effectTotal > max ? effectTotal : max;
       },
     );
   }
@@ -163,8 +164,8 @@ Future<T?> showShadDialog<T>({
       barrierLabel: barrierLabel,
       anchorPoint: anchorPoint,
       settings: routeSettings,
-      transitionDuration: getEffectsDuration(effectiveAnimateIn),
-      reverseTransitionDuration: getEffectsDuration(effectiveAnimateOut),
+      transitionDuration: maxCompletionDuration(effectiveAnimateIn),
+      reverseTransitionDuration: maxCompletionDuration(effectiveAnimateOut),
       transitionBuilder: (context, animation, secondaryAnimation, child) {
         if (animation.status == AnimationStatus.completed) {
           return child;


### PR DESCRIPTION
A minor improvement.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making.
- [ ] I followed the [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.
- [ ] I bumped the package version following the [Semantic Versioning](https://semver.org/) guidelines (For now the major is the second number and the minor the third, because the package is not feature complete). For example, if the package is at version `0.18.0` and you introduced a breaking change or a new feature, bump it to `0.19.0`, if you just added a fix or a chore bump it to `0.18.1`.
- [ ] I updated the `CHANGELOG.md` file with a summary of changes made following the format already used.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[Contributor Guide]: [https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview](https://github.com/nank1ro/flutter-shadcn-ui/blob/main/CONTRIBUTING.md)
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Discord]: https://discord.gg/ZhRMAPNh5Y
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dialog animations now use the maximum combined delay and duration across effects for both opening and closing transitions, preventing premature completion and ensuring smoother, synchronized motion when multiple effects are applied. Both forward and reverse animations align to the same computed timing. No changes to the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->