### PR TITLE
fix: Disable text selection inside buttons

### DIFF
--- a/lib/src/components/button.dart
+++ b/lib/src/components/button.dart
@@ -1116,21 +1116,23 @@ class _ShadButtonState extends State<ShadButton> {
                         onLongPressDown: widget.onLongPressDown,
                         onLongPressStart: widget.onLongPressStart,
                         longPressDuration: effectiveLongPressDuration,
-                        child: SizedBox(
-                          height: height(theme),
-                          width: width(theme),
-                          child: Padding(
-                            padding: padding(theme),
-                            child: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              crossAxisAlignment: effectiveCrossAxisAlignment,
-                              mainAxisAlignment: effectiveMainAxisAlignment,
-                              textDirection: effectiveTextDirection,
-                              children: [
-                                ?widget.leading,
-                                ?child,
-                                ?widget.trailing,
-                              ].separatedBy(SizedBox(width: effectiveGap)),
+                        child: SelectionContainer.disabled(
+                          child: SizedBox(
+                            height: height(theme),
+                            width: width(theme),
+                            child: Padding(
+                              padding: padding(theme),
+                              child: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                crossAxisAlignment: effectiveCrossAxisAlignment,
+                                mainAxisAlignment: effectiveMainAxisAlignment,
+                                textDirection: effectiveTextDirection,
+                                children: [
+                                  ?widget.leading,
+                                  ?child,
+                                  ?widget.trailing,
+                                ].separatedBy(SizedBox(width: effectiveGap)),
+                              ),
                             ),
                           ),
                         ),


### PR DESCRIPTION
# Changes

Makes the text in buttons not selectable. If you wrap the app in a `SelectionArea` then all the text widgets inside shad buttons become selectable with the selection mouse pointer, even if the cursor is set to something else, in the shad button.

This PR disables the text selection even if the button is underneath a `SelectionArea` in the widget-tree. For apps without the `SelectionArea` this change has no effect.

I have not added an option for this configuration as I don't think it is desirable for the text to be selectable in 99% of the cases. If such an option were introduced, it should interact with the cursor option reasonably.

Demo code:
```dart
class ButtonPage extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return SelectionArea(
      child: Scaffold(
        body: Center(
          child: ShadButton(
            child: const Text('Primary'),
            onPressed: () {},
          ),
        ),
      ),
    );
  }
}
```

**Before:**

https://github.com/user-attachments/assets/c462a61f-8dd3-49e9-808f-90a8f7897d6d

**After:**

https://github.com/user-attachments/assets/44fe576f-e5c7-4ecf-97f5-42b2afa0d3d5


 

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making.
- [ ] I followed the [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.
- [ ] I bumped the package version following the [Semantic Versioning](https://semver.org/) guidelines (For now the major is the second number and the minor the third, because the package is not feature complete). For example, if the package is at version `0.18.0` and you introduced a breaking change or a new feature, bump it to `0.19.0`, if you just added a fix or a chore bump it to `0.18.1`.
- [ ] I updated the `CHANGELOG.md` file with a summary of changes made following the format already used.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[Contributor Guide]: [https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview](https://github.com/nank1ro/flutter-shadcn-ui/blob/main/CONTRIBUTING.md)
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Discord]: https://discord.gg/ZhRMAPNh5Y
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Button content is now non-selectable, preventing text selection within buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->