### PR TITLE
feat: select on pressed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.39.5
+
+- **FEAT**: Add `onPressed` to `ShadSelect` and its form fields to provide a custom callback when the select input is pressed, instead of toggling the popover.
+
 ## 0.39.4
 
 - **FIX**: `ShadDatePicker` selected range not updated inside `didUpdateWidget`.

--- a/lib/src/components/form/fields/select.dart
+++ b/lib/src/components/form/fields/select.dart
@@ -105,6 +105,9 @@ class ShadSelectFormField<T> extends ShadFormBuilderField<T> {
 
     /// {@macro ShadSelect.ensureSelectedVisible}
     bool? ensureSelectedVisible,
+
+    /// {@macro ShadSelect.onPressed}
+    VoidCallback? onPressed,
   }) : super(
          decorationBuilder: (context) =>
              (ShadTheme.of(context).selectTheme.decoration ??
@@ -145,6 +148,7 @@ class ShadSelectFormField<T> extends ShadFormBuilderField<T> {
              shrinkWrap: shrinkWrap,
              controller: state.controller,
              ensureSelectedVisible: ensureSelectedVisible,
+             onPressed: onPressed,
            );
          },
        );
@@ -221,6 +225,9 @@ class ShadSelectFormField<T> extends ShadFormBuilderField<T> {
 
     /// {@macro ShadSelect.onSearchSubmitted}
     ValueChanged<String>? onSearchSubmitted,
+
+    /// {@macro ShadSelect.onPressed}
+    VoidCallback? onPressed,
   }) : super(
          decorationBuilder: (context) =>
              (ShadTheme.of(context).selectTheme.decoration ??
@@ -270,6 +277,7 @@ class ShadSelectFormField<T> extends ShadFormBuilderField<T> {
              ensureSelectedVisible: ensureSelectedVisible,
              searchFocusNode: searchFocusNode,
              onSearchSubmitted: onSearchSubmitted,
+             onPressed: onPressed,
            );
          },
        );
@@ -346,6 +354,9 @@ class ShadSelectFormField<T> extends ShadFormBuilderField<T> {
 
     /// {@macro ShadSelect.onSearchSubmitted}
     ValueChanged<String>? onSearchSubmitted,
+
+    /// {@macro ShadSelect.onPressed}
+    VoidCallback? onPressed,
   }) : assert(
          variant == ShadSelectVariant.primary ||
              variant == ShadSelectVariant.search,
@@ -400,6 +411,7 @@ class ShadSelectFormField<T> extends ShadFormBuilderField<T> {
              ensureSelectedVisible: ensureSelectedVisible,
              searchFocusNode: searchFocusNode,
              onSearchSubmitted: onSearchSubmitted,
+             onPressed: onPressed,
            );
          },
        );

--- a/lib/src/components/select.dart
+++ b/lib/src/components/select.dart
@@ -81,6 +81,7 @@ class ShadSelect<T> extends StatefulWidget {
     this.controller,
     this.popoverReverseDuration,
     this.ensureSelectedVisible,
+    this.onPressed,
   }) : variant = ShadSelectVariant.primary,
        initialValues = const {},
        onSearchChanged = null,
@@ -146,6 +147,7 @@ class ShadSelect<T> extends StatefulWidget {
     this.ensureSelectedVisible,
     this.searchFocusNode,
     this.onSearchSubmitted,
+    this.onPressed,
   }) : variant = ShadSelectVariant.search,
        selectedOptionsBuilder = null,
        onMultipleChanged = null,
@@ -197,6 +199,7 @@ class ShadSelect<T> extends StatefulWidget {
     this.controller,
     this.popoverReverseDuration,
     this.ensureSelectedVisible,
+    this.onPressed,
   }) : variant = ShadSelectVariant.multiple,
        onSearchChanged = null,
        initialValue = null,
@@ -263,6 +266,7 @@ class ShadSelect<T> extends StatefulWidget {
     this.ensureSelectedVisible,
     this.searchFocusNode,
     this.onSearchSubmitted,
+    this.onPressed,
   }) : variant = ShadSelectVariant.multipleWithSearch,
        selectedOptionBuilder = null,
        onChanged = null,
@@ -328,6 +332,7 @@ class ShadSelect<T> extends StatefulWidget {
     this.ensureSelectedVisible,
     this.searchFocusNode,
     this.onSearchSubmitted,
+    this.onPressed,
   }) : assert(
          variant == ShadSelectVariant.primary || onSearchChanged != null,
          'onSearchChanged must be provided when variant is search',
@@ -678,6 +683,14 @@ class ShadSelect<T> extends StatefulWidget {
   /// Provides the current search string as an argument.
   /// {@endtemplate}
   final ValueChanged<String>? onSearchSubmitted;
+
+  /// {@template ShadSelect.onPressed}
+  /// Callback function invoked when the select input is pressed.
+  ///
+  /// If provided, this callback will be called instead of toggling the
+  /// popover.
+  /// {@endtemplate}
+  final VoidCallback? onPressed;
 
   @override
   ShadSelectState<T> createState() => ShadSelectState();
@@ -1062,6 +1075,10 @@ class ShadSelectState<T> extends State<ShadSelect<T>> {
                   cursor: SystemMouseCursors.click,
                   behavior: HitTestBehavior.opaque,
                   onTap: () {
+                    if (widget.onPressed != null) {
+                      widget.onPressed!();
+                      return;
+                    }
                     FocusScope.of(context).unfocus();
                     popoverController.toggle();
                   },

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shadcn_ui
 description: shadcn/ui ported in Flutter. Awesome UI components for Flutter, fully customizable.
-version: 0.39.4
+version: 0.39.5
 homepage: https://flutter-shadcn-ui.mariuti.com
 repository: https://github.com/nank1ro/flutter-shadcn-ui
 documentation: https://flutter-shadcn-ui.mariuti.com


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
-->

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue. An issue is not required if the PR fixes something trivial like a typo.*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making.
- [ ] I followed the [Data Driven Fixes] where supported.
- [ ] All existing and new tests are passing.
- [ ] I bumped the package version following the [Semantic Versioning](https://semver.org/) guidelines (For now the major is the second number and the minor the third, because the package is not feature complete). For example, if the package is at version `0.18.0` and you introduced a breaking change or a new feature, bump it to `0.19.0`, if you just added a fix or a chore bump it to `0.18.1`.
- [ ] I updated the `CHANGELOG.md` file with a summary of changes made following the format already used.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[Contributor Guide]: [https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview](https://github.com/nank1ro/flutter-shadcn-ui/blob/main/CONTRIBUTING.md)
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Discord]: https://discord.gg/ZhRMAPNh5Y
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional onPressed callback parameter to select components and all form field variants. When provided, this callback handles press events on the select input, enabling custom behavior as an alternative to the default popover toggle. The feature is now available across all variant types, including search-enabled and raw options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->