### PR TITLE
fix: Align checkbox colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.53.4
+
+- **FIX**: `ShadCheckbox` unchecked color now matches the theme's `input` color. (thanks to @Isakdl)
+
 ## 0.53.3
 
 - **FIX**: Keyboard navigation in `ShadSlider` now works correctly with the Shift and arrow keys. (thanks to @Isakdl)

--- a/lib/src/components/checkbox.dart
+++ b/lib/src/components/checkbox.dart
@@ -176,7 +176,7 @@ class _ShadCheckboxState extends State<ShadCheckbox> {
     final effectiveUncheckedColor =
         widget.uncheckedColor ??
         theme.checkboxTheme.uncheckedColor ??
-        theme.colorScheme.input;
+        const Color(0x00000000);
 
     final effectiveDecoration =
         (theme.checkboxTheme.decoration ?? const ShadDecoration())

--- a/lib/src/theme/themes/default_theme_variant.dart
+++ b/lib/src/theme/themes/default_theme_variant.dart
@@ -487,12 +487,11 @@ class ShadDefaultThemeVariant extends ShadThemeVariant {
       size: 16,
       duration: 100.milliseconds,
       color: colorScheme.primary,
-      uncheckedColor: colorScheme.input,
       padding: const EdgeInsetsDirectional.only(start: 8),
       checkboxPadding: const EdgeInsets.only(top: 1),
       decoration: ShadDecoration(
         border: ShadBorder.all(
-          color: colorScheme.primary,
+          color: colorScheme.border,
           radius: radius,
           width: 1,
         ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shadcn_ui
 description: shadcn/ui ported in Flutter. Awesome UI components for Flutter, fully customizable.
-version: 0.53.3
+version: 0.53.4
 homepage: https://mariuti.com/flutter-shadcn-ui
 repository: https://github.com/nank1ro/flutter-shadcn-ui
 documentation: https://mariuti.com/flutter-shadcn-ui


### PR DESCRIPTION
<!--
Thanks for filing a pull request!
-->


<img width="476" height="129" alt="Screenshot 2026-03-30 at 22 22 50" src="https://github.com/user-attachments/assets/1dddf2e7-dc4a-4ea3-a332-5b649fff7960" />

<img width="442" height="137" alt="Screenshot 2026-03-30 at 22 22 58" src="https://github.com/user-attachments/assets/114aa48a-e096-4854-ba42-8d105e49b91a" />

Replace the border color of checkboxes from "primary" to "border".
Reinstate the transparent color of checkboxes. The previous behavior was correct for dark mode, however the darkmode color are not aligned for any other Flutter input fields theming.

The React theme has the input background color of #FFFFFFF / 15% opacity * 30% opacity. 

Setting the color to transparent does align the color for all inputs, I think being consistent is better than having the "right" color.

## Testing this PR

<!--
Update the `ref` below with your branch name, then users can test your changes by adding this to their `pubspec.yaml`:
-->
To try this branch, add the following to your `pubspec.yaml`:

```yaml
shadcn_ui:
    git:
      url: https://github.com/nank1ro/flutter-shadcn-ui
      ref: your-branch-name-here
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making.
- [x] I followed the [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
- [x] I bumped the package version following the [Semantic Versioning](https://semver.org/) guidelines (For now the major is the second number and the minor the third, because the package is not feature complete). For example, if the package is at version `0.18.0` and you introduced a breaking change or a new feature, bump it to `0.19.0`, if you just added a fix or a chore bump it to `0.18.1`.
- [x] I updated the `CHANGELOG.md` file with a summary of changes made following the format already used.

If you need help, consider asking for advice on [Discord].

<!-- Links -->
[Contributor Guide]: [https://github.com/flutter/flutter/blob/main/docs/contributing/Tree-hygiene.md#overview](https://github.com/nank1ro/flutter-shadcn-ui/blob/main/CONTRIBUTING.md)
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/main/docs/contributing/Style-guide-for-Flutter-repo.md
[Discord]: https://discord.gg/ZhRMAPNh5Y
[Data Driven Fixes]: https://github.com/flutter/flutter/blob/main/docs/contributing/Data-driven-Fixes.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed checkbox styling: unchecked state color now properly aligns with the theme's input color scheme for consistent visual appearance.

* **Chores**
  * Version bumped to 0.53.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->