### PR TITLE
fix: apply theme fallback for buttonDecoration in ShadDatePicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.53.5
+
+- **FIX**: `ShadDatePicker` now correctly falls back to `datePickerTheme.buttonDecoration` when no explicit `buttonDecoration` is provided.
+
 ## 0.53.4
 
 - **FEAT**: Add per-tab `maintainState` support to `ShadTab`. Individual `ShadTab` widgets can now override the global `ShadTabs.maintainState` setting.

--- a/lib/src/components/date_picker.dart
+++ b/lib/src/components/date_picker.dart
@@ -1263,7 +1263,8 @@ class _ShadDatePickerState extends State<ShadDatePicker> {
         );
       },
       child: ShadButton.raw(
-        decoration: widget.buttonDecoration,
+        decoration:
+            widget.buttonDecoration ?? theme.datePickerTheme.buttonDecoration,
         variant:
             widget.buttonVariant ??
             theme.datePickerTheme.buttonVariant ??

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shadcn_ui
 description: shadcn/ui ported in Flutter. Awesome UI components for Flutter, fully customizable.
-version: 0.53.4
+version: 0.53.5
 homepage: https://mariuti.com/flutter-shadcn-ui
 repository: https://github.com/nank1ro/flutter-shadcn-ui
 documentation: https://mariuti.com/flutter-shadcn-ui


### PR DESCRIPTION
The buttonDecoration property in ShadDatePicker was being used directly from the widget without falling back to theme.datePickerTheme.buttonDecoration, unlike all other button-related properties. This caused the themed border configuration to be ignored in ShadDatePicker and ShadDateRangePickerFormField.

Changes:
- `lib/src/components/date_picker.dart`: changed `decoration: widget.buttonDecoration` to `decoration: widget.buttonDecoration ?? theme.datePickerTheme.buttonDecoration`

Fixes #646

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Date picker button styling now correctly falls back to the theme when no custom decoration is provided.

* **Documentation**
  * Added changelog entry for release 0.53.5 noting the fix.

* **Chores**
  * Package version updated to 0.53.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->