### PR TITLE
feat: add per-tab maintainState support to ShadTab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.53.4
+
+- **FEAT**: Add per-tab `maintainState` support to `ShadTab`. Individual `ShadTab` widgets can now override the global `ShadTabs.maintainState` setting.
+
 ## 0.53.3
 
 - **FIX**: Keyboard navigation in `ShadSlider` now works correctly with the Shift and arrow keys. (thanks to @Isakdl)

--- a/lib/src/components/tabs.dart
+++ b/lib/src/components/tabs.dart
@@ -351,7 +351,9 @@ class ShadTabsState<T> extends State<ShadTabs<T>> with RestorationMixin {
               ...List<Widget>.generate(widget.tabs.length, (int index) {
                 final tab = widget.tabs[index];
                 final selected = tab.value == controller.selected;
-                if (!selected && !effectiveMaintainState) {
+                final effectiveTabMaintainState =
+                    tab.maintainState ?? effectiveMaintainState;
+                if (!selected && !effectiveTabMaintainState) {
                   return const SizedBox.shrink();
                 }
                 Widget content = Offstage(
@@ -449,6 +451,7 @@ class ShadTab<T> extends StatefulWidget implements PreferredSizeWidget {
     this.onDoubleTapCancel,
     this.longPressDuration,
     this.expandContent,
+    this.maintainState,
   });
 
   /// {@template ShadTab.value}
@@ -713,6 +716,15 @@ class ShadTab<T> extends StatefulWidget implements PreferredSizeWidget {
   /// Whether the tab content should be expanded, defaults to `false`.
   /// {@endtemplate}
   final bool? expandContent;
+
+  /// {@template ShadTab.maintainState}
+  /// Whether to maintain the state of this tab when switching away from it.
+  ///
+  /// When set, overrides the global [ShadTabs.maintainState] for this specific
+  /// tab. When null, falls back to [ShadTabs.maintainState] (which defaults to
+  /// true).
+  /// {@endtemplate}
+  final bool? maintainState;
 
   @override
   State<ShadTab<T>> createState() => _ShadTabState<T>();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shadcn_ui
 description: shadcn/ui ported in Flutter. Awesome UI components for Flutter, fully customizable.
-version: 0.53.3
+version: 0.53.4
 homepage: https://mariuti.com/flutter-shadcn-ui
 repository: https://github.com/nank1ro/flutter-shadcn-ui
 documentation: https://mariuti.com/flutter-shadcn-ui


### PR DESCRIPTION
Closes #647

Allow individual `ShadTab` widgets to override the global `maintainState` setting from `ShadTabs`. When `ShadTab.maintainState` is set, it takes precedence over `ShadTabs.maintainState` for that specific tab.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-tab state preservation control: individual tabs can now override the global setting to determine whether inactive tabs retain their content in memory.

* **Chores**
  * Updated the changelog and bumped the package version for the new release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->