### PR TITLE
feat: add agent skills support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ Awesome UI components for Flutter, fully customizable.
 
 See the [documentation](https://mariuti.com/flutter-shadcn-ui/) to interact with the components and see the code.
 
+### Agent Skills
+
+You can install the [Agent Skills](https://agentskills.io) for this project with:
+
+```bash
+npx skills add nank1ro/flutter-shadcn-ui
+```
+
 ## Progress
 
 > Follow the progress on [X (Twitter)](https://twitter.com/nank1ro)

--- a/docs/src/content/docs/index.md
+++ b/docs/src/content/docs/index.md
@@ -14,7 +14,12 @@ This is the official documentation for Shadcn UI for Flutter.
 > The work is still in progress.
 
 :::tip[AI Editor Integration]
-If you want to consume the docs in a LLM that accepts markdown, you can use this link:
+For compatible coding agents that support [Agent Skills](https://agentskills.io), you can install with this command:
+```bash
+npx skills add nank1ro/flutter-shadcn-ui
+```
+
+Alternatively, you can use this link:
 <https://mariuti.com/flutter-shadcn-ui/llms.txt>
 :::
 

--- a/scripts/generate_skills.dart
+++ b/scripts/generate_skills.dart
@@ -1,31 +1,29 @@
-// ignore_for_file: avoid_print
+// ignore_for_file: avoid_print, lines_longer_than_80_chars
 
 import 'dart:io';
 
 class ComponentInfo {
-  final String name;
-  final String fileName;
-  final String description;
-  final String content;
-
   ComponentInfo({
     required this.name,
     required this.fileName,
     required this.description,
     required this.content,
   });
+  final String name;
+  final String fileName;
+  final String description;
+  final String content;
 }
 
 class GuideInfo {
-  final String title;
-  final String fileName;
-  final String content;
-
   GuideInfo({
     required this.title,
     required this.fileName,
     required this.content,
   });
+  final String title;
+  final String fileName;
+  final String content;
 }
 
 void main() async {
@@ -36,7 +34,7 @@ void main() async {
   final utilsDir = Directory('docs/src/content/docs/Utils');
   final packagesFile = File('docs/src/content/docs/packages.md');
   final outputDir = Directory('skills/shadcn-ui-flutter');
-  
+
   if (!outputDir.existsSync()) {
     outputDir.createSync(recursive: true);
   }
@@ -51,17 +49,23 @@ void main() async {
     for (final file in componentsDir.listSync().whereType<File>()) {
       if (file.path.endsWith('.mdx')) {
         final content = await file.readAsString();
-        final name = _extractTitle(content) ?? file.uri.pathSegments.last.replaceAll('.mdx', '');
+        final name =
+            _extractTitle(content) ??
+            file.uri.pathSegments.last.replaceAll('.mdx', '');
         final cleanedContent = _cleanMdx(content);
         final description = _extractDescription(cleanedContent);
-        final exampleContent = await _getExampleContent(file.uri.pathSegments.last.replaceAll('.mdx', ''));
-        
-        components.add(ComponentInfo(
-          name: name,
-          fileName: file.uri.pathSegments.last.replaceAll('.mdx', '.md'),
-          description: description,
-          content: '$cleanedContent\n\n$exampleContent',
-        ));
+        final exampleContent = await _getExampleContent(
+          file.uri.pathSegments.last.replaceAll('.mdx', ''),
+        );
+
+        components.add(
+          ComponentInfo(
+            name: name,
+            fileName: file.uri.pathSegments.last.replaceAll('.mdx', '.md'),
+            description: description,
+            content: '$cleanedContent\n\n$exampleContent',
+          ),
+        );
       }
     }
   }
@@ -69,41 +73,53 @@ void main() async {
 
   print('Generating component files...');
   for (final comp in components) {
-    final compFile = File('skills/shadcn-ui-flutter/components/${comp.fileName}');
+    final compFile = File(
+      'skills/shadcn-ui-flutter/components/${comp.fileName}',
+    );
     await compFile.writeAsString('# ${comp.name}\n\n${comp.content}');
   }
 
   print('Parsing guides...');
   final guides = <GuideInfo>[];
-  
+
   if (themeFile.existsSync()) {
     final themeContent = await themeFile.readAsString();
-    guides.add(GuideInfo(
-      title: 'Theming',
-      fileName: 'theming.md',
-      content: _cleanMdx(themeContent),
-    ));
+    guides.add(
+      GuideInfo(
+        title: 'Theming',
+        fileName: 'theming.md',
+        content: _cleanMdx(themeContent),
+      ),
+    );
   }
 
   if (typographyFile.existsSync()) {
     final typoContent = await typographyFile.readAsString();
-    guides.add(GuideInfo(
-      title: 'Typography',
-      fileName: 'typography.md',
-      content: _cleanMdx(typoContent),
-    ));
+    guides.add(
+      GuideInfo(
+        title: 'Typography',
+        fileName: 'typography.md',
+        content: _cleanMdx(typoContent),
+      ),
+    );
   }
 
   if (indexFile.existsSync()) {
     final indexContent = await indexFile.readAsString();
     final materialSection = _extractSection(indexContent, 'Shadcn + Material');
-    final cupertinoSection = _extractSection(indexContent, 'Shadcn + Cupertino');
+    final cupertinoSection = _extractSection(
+      indexContent,
+      'Shadcn + Cupertino',
+    );
     if (materialSection.isNotEmpty || cupertinoSection.isNotEmpty) {
-      guides.add(GuideInfo(
-        title: 'Material & Cupertino Interop',
-        fileName: 'interop.md',
-        content: '# Interoperability\n\n$materialSection\n\n$cupertinoSection',
-      ));
+      guides.add(
+        GuideInfo(
+          title: 'Material & Cupertino Interop',
+          fileName: 'interop.md',
+          content:
+              '# Interoperability\n\n$materialSection\n\n$cupertinoSection',
+        ),
+      );
     }
   }
 
@@ -112,12 +128,19 @@ void main() async {
       final path = file.path;
       if (path.endsWith('.md') || path.endsWith('.mdx')) {
         final content = await file.readAsString();
-        final title = _extractTitle(content) ?? file.uri.pathSegments.last.replaceAll(RegExp(r'\.mdx?'), '');
-        guides.add(GuideInfo(
-          title: title,
-          fileName: file.uri.pathSegments.last.replaceAll(RegExp(r'\.mdx?'), '.md'),
-          content: _cleanMdx(content),
-        ));
+        final title =
+            _extractTitle(content) ??
+            file.uri.pathSegments.last.replaceAll(RegExp(r'\.mdx?'), '');
+        guides.add(
+          GuideInfo(
+            title: title,
+            fileName: file.uri.pathSegments.last.replaceAll(
+              RegExp(r'\.mdx?'),
+              '.md',
+            ),
+            content: _cleanMdx(content),
+          ),
+        );
       }
     }
   }
@@ -147,16 +170,19 @@ String? _extractTitle(String content) {
 String _cleanMdx(String content) {
   // Remove frontmatter
   var cleaned = content.replaceFirst(RegExp(r'^---[\s\S]*?---'), '');
-  
+
   // Remove Astro imports
   cleaned = cleaned.replaceAll(RegExp(r'^import .*?;$', multiLine: true), '');
-  
+
   // Remove <Preview> tags but keep content inside
-  cleaned = cleaned.replaceAll(RegExp(r'<Preview.*?>'), '');
+  cleaned = cleaned.replaceAll(RegExp('<Preview.*?>'), '');
   cleaned = cleaned.replaceAll('</Preview>', '');
-  
+
   // Remove other common MDX components if any
-  cleaned = cleaned.replaceAll(RegExp(r':::.+?(\n|$)'), ''); // :::tip, :::note etc
+  cleaned = cleaned.replaceAll(
+    RegExp(r':::.+?(\n|$)'),
+    '',
+  ); // :::tip, :::note etc
   cleaned = cleaned.replaceAll(':::', '');
 
   return cleaned.trim();
@@ -166,7 +192,9 @@ String _extractDescription(String content) {
   final lines = content.split('\n');
   for (final line in lines) {
     final trimmed = line.trim();
-    if (trimmed.isNotEmpty && !trimmed.startsWith('#') && !trimmed.startsWith('![')) {
+    if (trimmed.isNotEmpty &&
+        !trimmed.startsWith('#') &&
+        !trimmed.startsWith('![')) {
       return trimmed;
     }
   }
@@ -177,7 +205,7 @@ String _extractSection(String content, String sectionTitle) {
   final lines = content.split('\n');
   var inSection = false;
   final sectionLines = <String>[];
-  
+
   for (final line in lines) {
     if (line.startsWith('## ') && line.contains(sectionTitle)) {
       inSection = true;
@@ -194,22 +222,34 @@ String _extractSection(String content, String sectionTitle) {
   return sectionLines.join('\n').trim();
 }
 
-String _generateSkillMd(List<ComponentInfo> components, List<GuideInfo> guides, String packagesContent) {
+String _generateSkillMd(
+  List<ComponentInfo> components,
+  List<GuideInfo> guides,
+  String packagesContent,
+) {
   final buffer = StringBuffer();
   buffer.writeln('---');
   buffer.writeln('name: shadcn-ui-flutter');
-  buffer.writeln('description: A comprehensive Flutter UI library inspired by shadcn/ui. Provides high-quality, customizable, and accessible components including Buttons, Cards, Forms, and more. Use this skill when building Flutter UIs, implementing design systems, or needing specific component usage examples.');
+  buffer.writeln(
+    'description: A comprehensive Flutter UI library inspired by shadcn/ui. Provides high-quality, customizable, and accessible components including Buttons, Cards, Forms, and more. Use this skill when building Flutter UIs, implementing design systems, or needing specific component usage examples.',
+  );
   buffer.writeln('---');
   buffer.writeln();
   buffer.writeln('# Shadcn UI for Flutter');
   buffer.writeln();
-  buffer.writeln('This skill provides documentation and examples for using the `shadcn_ui` package in Flutter.');
+  buffer.writeln(
+    'This skill provides documentation and examples for using the `shadcn_ui` package in Flutter.',
+  );
   buffer.writeln();
   buffer.writeln('## Theming and Customization');
-  buffer.writeln('Shadcn UI for Flutter provides a powerful theming system. You can use built-in color schemes (blue, gray, green, neutral, orange, red, rose, slate, stone, violet, yellow, zinc) or create your own.');
+  buffer.writeln(
+    'Shadcn UI for Flutter provides a powerful theming system. You can use built-in color schemes (blue, gray, green, neutral, orange, red, rose, slate, stone, violet, yellow, zinc) or create your own.',
+  );
   buffer.writeln();
   buffer.writeln('### Applying a Theme');
-  buffer.writeln('Use `ShadThemeData` within `ShadApp` to define your light and dark themes.');
+  buffer.writeln(
+    'Use `ShadThemeData` within `ShadApp` to define your light and dark themes.',
+  );
   buffer.writeln();
   buffer.writeln('### Detailed Guides');
   for (final guide in guides) {
@@ -220,14 +260,20 @@ String _generateSkillMd(List<ComponentInfo> components, List<GuideInfo> guides, 
   buffer.writeln('| Name | Description | Reference |');
   buffer.writeln('| :--- | :--- | :--- |');
   for (final comp in components) {
-    buffer.writeln('| ${comp.name} | ${comp.description} | [${comp.fileName}](components/${comp.fileName}) |');
+    buffer.writeln(
+      '| ${comp.name} | ${comp.description} | [${comp.fileName}](components/${comp.fileName}) |',
+    );
   }
   buffer.writeln();
   buffer.writeln('## Usage Examples');
-  buffer.writeln('Examples are available at the bottom of each component page.');
+  buffer.writeln(
+    'Examples are available at the bottom of each component page.',
+  );
   buffer.writeln();
   buffer.writeln('### Basic Setup');
-  buffer.writeln('Here is a complete example of a Counter App using `shadcn_ui`, including light and dark theme support.');
+  buffer.writeln(
+    'Here is a complete example of a Counter App using `shadcn_ui`, including light and dark theme support.',
+  );
   buffer.writeln('```dart');
   buffer.writeln("import 'package:shadcn_ui/shadcn_ui.dart';");
   buffer.writeln();
@@ -276,17 +322,19 @@ String _generateSkillMd(List<ComponentInfo> components, List<GuideInfo> guides, 
   buffer.writeln('  Widget build(BuildContext context) {');
   buffer.writeln('    final theme = ShadTheme.of(context);');
   buffer.writeln('    return Scaffold(');
-  buffer.writeln('      appBar: AppBar(title: const Text(\'Shadcn Counter\')),');
+  buffer.writeln("      appBar: AppBar(title: const Text('Shadcn Counter')),");
   buffer.writeln('      body: Center(');
   buffer.writeln('        child: Column(');
   buffer.writeln('          mainAxisAlignment: MainAxisAlignment.center,');
   buffer.writeln('          children: [');
   buffer.writeln('            Text(');
-  buffer.writeln('              \'You have pushed the button this many times:\',');
+  buffer.writeln(
+    "              'You have pushed the button this many times:',",
+  );
   buffer.writeln('              style: theme.textTheme.muted,');
   buffer.writeln('            ),');
   buffer.writeln('            Text(');
-  buffer.writeln('              \'\$_counter\',');
+  buffer.writeln(r"              '$_counter',");
   buffer.writeln('              style: theme.textTheme.h1,');
   buffer.writeln('            ),');
   buffer.writeln('          ],');
@@ -300,12 +348,12 @@ String _generateSkillMd(List<ComponentInfo> components, List<GuideInfo> guides, 
   buffer.writeln('  }');
   buffer.writeln('}');
   buffer.writeln('```');
-  
+
   if (packagesContent.isNotEmpty) {
     buffer.writeln();
     buffer.writeln(packagesContent);
   }
-  
+
   return buffer.toString();
 }
 
@@ -313,15 +361,15 @@ Future<String> _getExampleContent(String componentName) async {
   final name = componentName.replaceAll('-', '_');
   final mainExample = File('example/lib/pages/$name.dart');
   final formExample = File('example/lib/pages/${name}_form_field.dart');
-  
+
   final buffer = StringBuffer();
-  
+
   if (mainExample.existsSync()) {
     buffer.writeln('## Example');
     buffer.writeln('```dart');
     buffer.writeln(await mainExample.readAsString());
     buffer.writeln('```');
-    
+
     if (formExample.existsSync()) {
       buffer.writeln('\n## Form Example');
       buffer.writeln('```dart');
@@ -334,6 +382,6 @@ Future<String> _getExampleContent(String componentName) async {
     buffer.writeln(await formExample.readAsString());
     buffer.writeln('```');
   }
-  
+
   return buffer.toString();
 }

--- a/scripts/generate_skills.dart
+++ b/scripts/generate_skills.dart
@@ -1,0 +1,339 @@
+// ignore_for_file: avoid_print
+
+import 'dart:io';
+
+class ComponentInfo {
+  final String name;
+  final String fileName;
+  final String description;
+  final String content;
+
+  ComponentInfo({
+    required this.name,
+    required this.fileName,
+    required this.description,
+    required this.content,
+  });
+}
+
+class GuideInfo {
+  final String title;
+  final String fileName;
+  final String content;
+
+  GuideInfo({
+    required this.title,
+    required this.fileName,
+    required this.content,
+  });
+}
+
+void main() async {
+  final componentsDir = Directory('docs/src/content/docs/Components');
+  final themeFile = File('docs/src/content/docs/Theme/data.md');
+  final typographyFile = File('docs/src/content/docs/typography.mdx');
+  final indexFile = File('docs/src/content/docs/index.md');
+  final utilsDir = Directory('docs/src/content/docs/Utils');
+  final packagesFile = File('docs/src/content/docs/packages.md');
+  final outputDir = Directory('skills/shadcn-ui-flutter');
+  
+  if (!outputDir.existsSync()) {
+    outputDir.createSync(recursive: true);
+  }
+
+  // Ensure subdirectories exist
+  Directory('skills/shadcn-ui-flutter/components').createSync(recursive: true);
+  Directory('skills/shadcn-ui-flutter/guides').createSync(recursive: true);
+
+  print('Parsing components...');
+  final components = <ComponentInfo>[];
+  if (componentsDir.existsSync()) {
+    for (final file in componentsDir.listSync().whereType<File>()) {
+      if (file.path.endsWith('.mdx')) {
+        final content = await file.readAsString();
+        final name = _extractTitle(content) ?? file.uri.pathSegments.last.replaceAll('.mdx', '');
+        final cleanedContent = _cleanMdx(content);
+        final description = _extractDescription(cleanedContent);
+        final exampleContent = await _getExampleContent(file.uri.pathSegments.last.replaceAll('.mdx', ''));
+        
+        components.add(ComponentInfo(
+          name: name,
+          fileName: file.uri.pathSegments.last.replaceAll('.mdx', '.md'),
+          description: description,
+          content: '$cleanedContent\n\n$exampleContent',
+        ));
+      }
+    }
+  }
+  components.sort((a, b) => a.name.compareTo(b.name));
+
+  print('Generating component files...');
+  for (final comp in components) {
+    final compFile = File('skills/shadcn-ui-flutter/components/${comp.fileName}');
+    await compFile.writeAsString('# ${comp.name}\n\n${comp.content}');
+  }
+
+  print('Parsing guides...');
+  final guides = <GuideInfo>[];
+  
+  if (themeFile.existsSync()) {
+    final themeContent = await themeFile.readAsString();
+    guides.add(GuideInfo(
+      title: 'Theming',
+      fileName: 'theming.md',
+      content: _cleanMdx(themeContent),
+    ));
+  }
+
+  if (typographyFile.existsSync()) {
+    final typoContent = await typographyFile.readAsString();
+    guides.add(GuideInfo(
+      title: 'Typography',
+      fileName: 'typography.md',
+      content: _cleanMdx(typoContent),
+    ));
+  }
+
+  if (indexFile.existsSync()) {
+    final indexContent = await indexFile.readAsString();
+    final materialSection = _extractSection(indexContent, 'Shadcn + Material');
+    final cupertinoSection = _extractSection(indexContent, 'Shadcn + Cupertino');
+    if (materialSection.isNotEmpty || cupertinoSection.isNotEmpty) {
+      guides.add(GuideInfo(
+        title: 'Material & Cupertino Interop',
+        fileName: 'interop.md',
+        content: '# Interoperability\n\n$materialSection\n\n$cupertinoSection',
+      ));
+    }
+  }
+
+  if (utilsDir.existsSync()) {
+    for (final file in utilsDir.listSync().whereType<File>()) {
+      final path = file.path;
+      if (path.endsWith('.md') || path.endsWith('.mdx')) {
+        final content = await file.readAsString();
+        final title = _extractTitle(content) ?? file.uri.pathSegments.last.replaceAll(RegExp(r'\.mdx?'), '');
+        guides.add(GuideInfo(
+          title: title,
+          fileName: file.uri.pathSegments.last.replaceAll(RegExp(r'\.mdx?'), '.md'),
+          content: _cleanMdx(content),
+        ));
+      }
+    }
+  }
+
+  print('Generating guide files...');
+  for (final guide in guides) {
+    final guideFile = File('skills/shadcn-ui-flutter/guides/${guide.fileName}');
+    await guideFile.writeAsString(guide.content);
+  }
+
+  print('Generating SKILL.md...');
+  var packagesContent = '';
+  if (packagesFile.existsSync()) {
+    packagesContent = _cleanMdx(await packagesFile.readAsString());
+  }
+  final skillMd = _generateSkillMd(components, guides, packagesContent);
+  await File('skills/shadcn-ui-flutter/SKILL.md').writeAsString(skillMd);
+
+  print('Done!');
+}
+
+String? _extractTitle(String content) {
+  final match = RegExp(r'^title:\s*(.*)$', multiLine: true).firstMatch(content);
+  return match?.group(1)?.trim();
+}
+
+String _cleanMdx(String content) {
+  // Remove frontmatter
+  var cleaned = content.replaceFirst(RegExp(r'^---[\s\S]*?---'), '');
+  
+  // Remove Astro imports
+  cleaned = cleaned.replaceAll(RegExp(r'^import .*?;$', multiLine: true), '');
+  
+  // Remove <Preview> tags but keep content inside
+  cleaned = cleaned.replaceAll(RegExp(r'<Preview.*?>'), '');
+  cleaned = cleaned.replaceAll('</Preview>', '');
+  
+  // Remove other common MDX components if any
+  cleaned = cleaned.replaceAll(RegExp(r':::.+?(\n|$)'), ''); // :::tip, :::note etc
+  cleaned = cleaned.replaceAll(':::', '');
+
+  return cleaned.trim();
+}
+
+String _extractDescription(String content) {
+  final lines = content.split('\n');
+  for (final line in lines) {
+    final trimmed = line.trim();
+    if (trimmed.isNotEmpty && !trimmed.startsWith('#') && !trimmed.startsWith('![')) {
+      return trimmed;
+    }
+  }
+  return '';
+}
+
+String _extractSection(String content, String sectionTitle) {
+  final lines = content.split('\n');
+  var inSection = false;
+  final sectionLines = <String>[];
+  
+  for (final line in lines) {
+    if (line.startsWith('## ') && line.contains(sectionTitle)) {
+      inSection = true;
+      sectionLines.add(line);
+      continue;
+    }
+    if (inSection && line.startsWith('## ')) {
+      break;
+    }
+    if (inSection) {
+      sectionLines.add(line);
+    }
+  }
+  return sectionLines.join('\n').trim();
+}
+
+String _generateSkillMd(List<ComponentInfo> components, List<GuideInfo> guides, String packagesContent) {
+  final buffer = StringBuffer();
+  buffer.writeln('---');
+  buffer.writeln('name: shadcn-ui-flutter');
+  buffer.writeln('description: A comprehensive Flutter UI library inspired by shadcn/ui. Provides high-quality, customizable, and accessible components including Buttons, Cards, Forms, and more. Use this skill when building Flutter UIs, implementing design systems, or needing specific component usage examples.');
+  buffer.writeln('---');
+  buffer.writeln();
+  buffer.writeln('# Shadcn UI for Flutter');
+  buffer.writeln();
+  buffer.writeln('This skill provides documentation and examples for using the `shadcn_ui` package in Flutter.');
+  buffer.writeln();
+  buffer.writeln('## Theming and Customization');
+  buffer.writeln('Shadcn UI for Flutter provides a powerful theming system. You can use built-in color schemes (blue, gray, green, neutral, orange, red, rose, slate, stone, violet, yellow, zinc) or create your own.');
+  buffer.writeln();
+  buffer.writeln('### Applying a Theme');
+  buffer.writeln('Use `ShadThemeData` within `ShadApp` to define your light and dark themes.');
+  buffer.writeln();
+  buffer.writeln('### Detailed Guides');
+  for (final guide in guides) {
+    buffer.writeln('- [${guide.title}](guides/${guide.fileName})');
+  }
+  buffer.writeln();
+  buffer.writeln('## Components');
+  buffer.writeln('| Name | Description | Reference |');
+  buffer.writeln('| :--- | :--- | :--- |');
+  for (final comp in components) {
+    buffer.writeln('| ${comp.name} | ${comp.description} | [${comp.fileName}](components/${comp.fileName}) |');
+  }
+  buffer.writeln();
+  buffer.writeln('## Usage Examples');
+  buffer.writeln('Examples are available at the bottom of each component page.');
+  buffer.writeln();
+  buffer.writeln('### Basic Setup');
+  buffer.writeln('Here is a complete example of a Counter App using `shadcn_ui`, including light and dark theme support.');
+  buffer.writeln('```dart');
+  buffer.writeln("import 'package:shadcn_ui/shadcn_ui.dart';");
+  buffer.writeln();
+  buffer.writeln('void main() {');
+  buffer.writeln('  runApp(const MyApp());');
+  buffer.writeln('}');
+  buffer.writeln();
+  buffer.writeln('class MyApp extends StatelessWidget {');
+  buffer.writeln('  const MyApp({super.key});');
+  buffer.writeln();
+  buffer.writeln('  @override');
+  buffer.writeln('  Widget build(BuildContext context) {');
+  buffer.writeln('    return ShadApp(');
+  buffer.writeln('      debugShowCheckedModeBanner: false,');
+  buffer.writeln('      theme: ShadThemeData(');
+  buffer.writeln('        brightness: Brightness.light,');
+  buffer.writeln('        colorScheme: const ShadZincColorScheme.light(),');
+  buffer.writeln('      ),');
+  buffer.writeln('      darkTheme: ShadThemeData(');
+  buffer.writeln('        brightness: Brightness.dark,');
+  buffer.writeln('        colorScheme: const ShadZincColorScheme.dark(),');
+  buffer.writeln('      ),');
+  buffer.writeln('      themeMode: ThemeMode.system,');
+  buffer.writeln('      home: const CounterPage(),');
+  buffer.writeln('    );');
+  buffer.writeln('  }');
+  buffer.writeln('}');
+  buffer.writeln();
+  buffer.writeln('class CounterPage extends StatefulWidget {');
+  buffer.writeln('  const CounterPage({super.key});');
+  buffer.writeln();
+  buffer.writeln('  @override');
+  buffer.writeln('  State<CounterPage> createState() => _CounterPageState();');
+  buffer.writeln('}');
+  buffer.writeln();
+  buffer.writeln('class _CounterPageState extends State<CounterPage> {');
+  buffer.writeln('  int _counter = 0;');
+  buffer.writeln();
+  buffer.writeln('  void _incrementCounter() {');
+  buffer.writeln('    setState(() {');
+  buffer.writeln('      _counter++;');
+  buffer.writeln('    });');
+  buffer.writeln('  }');
+  buffer.writeln();
+  buffer.writeln('  @override');
+  buffer.writeln('  Widget build(BuildContext context) {');
+  buffer.writeln('    final theme = ShadTheme.of(context);');
+  buffer.writeln('    return Scaffold(');
+  buffer.writeln('      appBar: AppBar(title: const Text(\'Shadcn Counter\')),');
+  buffer.writeln('      body: Center(');
+  buffer.writeln('        child: Column(');
+  buffer.writeln('          mainAxisAlignment: MainAxisAlignment.center,');
+  buffer.writeln('          children: [');
+  buffer.writeln('            Text(');
+  buffer.writeln('              \'You have pushed the button this many times:\',');
+  buffer.writeln('              style: theme.textTheme.muted,');
+  buffer.writeln('            ),');
+  buffer.writeln('            Text(');
+  buffer.writeln('              \'\$_counter\',');
+  buffer.writeln('              style: theme.textTheme.h1,');
+  buffer.writeln('            ),');
+  buffer.writeln('          ],');
+  buffer.writeln('        ),');
+  buffer.writeln('      ),');
+  buffer.writeln('      floatingActionButton: ShadButton(');
+  buffer.writeln('        onPressed: _incrementCounter,');
+  buffer.writeln('        child: const Icon(LucideIcons.plus),');
+  buffer.writeln('      ),');
+  buffer.writeln('    );');
+  buffer.writeln('  }');
+  buffer.writeln('}');
+  buffer.writeln('```');
+  
+  if (packagesContent.isNotEmpty) {
+    buffer.writeln();
+    buffer.writeln(packagesContent);
+  }
+  
+  return buffer.toString();
+}
+
+Future<String> _getExampleContent(String componentName) async {
+  final name = componentName.replaceAll('-', '_');
+  final mainExample = File('example/lib/pages/$name.dart');
+  final formExample = File('example/lib/pages/${name}_form_field.dart');
+  
+  final buffer = StringBuffer();
+  
+  if (mainExample.existsSync()) {
+    buffer.writeln('## Example');
+    buffer.writeln('```dart');
+    buffer.writeln(await mainExample.readAsString());
+    buffer.writeln('```');
+    
+    if (formExample.existsSync()) {
+      buffer.writeln('\n## Form Example');
+      buffer.writeln('```dart');
+      buffer.writeln(await formExample.readAsString());
+      buffer.writeln('```');
+    }
+  } else if (formExample.existsSync()) {
+    buffer.writeln('## Example');
+    buffer.writeln('```dart');
+    buffer.writeln(await formExample.readAsString());
+    buffer.writeln('```');
+  }
+  
+  return buffer.toString();
+}

--- a/skills/shadcn-ui-flutter/SKILL.md
+++ b/skills/shadcn-ui-flutter/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: shadcn-ui-flutter
+description: A comprehensive Flutter UI library inspired by shadcn/ui. Provides high-quality, customizable, and accessible components including Buttons, Cards, Forms, and more. Use this skill when building Flutter UIs, implementing design systems, or needing specific component usage examples.
+---
+
+# Shadcn UI for Flutter
+
+This skill provides documentation and examples for using the `shadcn_ui` package in Flutter.
+
+## Theming and Customization
+Shadcn UI for Flutter provides a powerful theming system. You can use built-in color schemes (blue, gray, green, neutral, orange, red, rose, slate, stone, violet, yellow, zinc) or create your own.
+
+### Applying a Theme
+Use `ShadThemeData` within `ShadApp` to define your light and dark themes.
+
+### Detailed Guides
+- [Theming](guides/theming.md)
+- [Typography](guides/typography.md)
+- [Material & Cupertino Interop](guides/interop.md)
+- [Responsive](guides/responsive.md)
+- [Decorator](guides/decorator.md)
+
+## Components
+| Name | Description | Reference |
+| :--- | :--- | :--- |
+| Accordion | A vertically stacked set of interactive headings that each reveal a section of content. | [accordion.md](components/accordion.md) |
+| Alert | Displays a callout for user attention. | [alert.md](components/alert.md) |
+| Avatar | An image element with a placeholder for representing the user. | [avatar.md](components/avatar.md) |
+| Badge | Displays a badge or a component that looks like a badge. | [badge.md](components/badge.md) |
+| Breadcrumb | Displays the path to the current resource using a hierarchy of links. | [breadcrumb.md](components/breadcrumb.md) |
+| Button | Displays a button or a component that looks like a button. | [button.md](components/button.md) |
+| Calendar | A date field component that allows users to enter and edit date. | [calendar.md](components/calendar.md) |
+| Card | Displays a card with header, content, and footer. | [card.md](components/card.md) |
+| Checkbox | A control that allows the user to toggle between checked and not checked. | [checkbox.md](components/checkbox.md) |
+| Context Menu | Displays a menu to the user — such as a set of actions or functions — triggered by a mouse right-click. | [context-menu.md](components/context-menu.md) |
+| Date Picker | A date picker component with range and presets. | [date-picker.md](components/date-picker.md) |
+| Dialog | A modal dialog that interrupts the user. | [dialog.md](components/dialog.md) |
+| Form | Builds a form with validation and easy access to form fields values. | [form.md](components/form.md) |
+| IconButton | Displays an icon button or a component that looks like a button with an icon. | [icon-button.md](components/icon-button.md) |
+| Input | Displays a form input field or a component that looks like an input field. | [input.md](components/input.md) |
+| InputOTP | Accessible one-time password component with copy paste functionality. | [input-otp.md](components/input-otp.md) |
+| Menubar | A visually persistent menu common in desktop applications that provides quick access to a consistent set of commands. | [menubar.md](components/menubar.md) |
+| Popover | Displays rich content in a portal, triggered by a button. | [popover.md](components/popover.md) |
+| Progress | Displays an indicator showing the completion progress of a task, typically displayed as a progress bar. | [progress.md](components/progress.md) |
+| RadioGroup | A set of checkable buttons—known as radio buttons—where no more than one of the buttons can be checked at a time. | [radio-group.md](components/radio-group.md) |
+| Resizable | Resizable panel groups and layouts. | [resizable.md](components/resizable.md) |
+| Select | Displays a list of options for the user to pick from—triggered by a button. | [select.md](components/select.md) |
+| Separator | Visually or semantically separates content. | [separator.md](components/separator.md) |
+| Sheet | Extends the Dialog component to display content that complements the main content of the screen. | [sheet.md](components/sheet.md) |
+| Slider | An input where the user selects a value from within a given range. | [slider.md](components/slider.md) |
+| Sonner | An opinionated toast component. | [sonner.md](components/sonner.md) |
+| Switch | A control that allows the user to toggle between checked and not checked. | [switch.md](components/switch.md) |
+| Table | A responsive table component. | [table.md](components/table.md) |
+| Tabs | A set of layered sections of content—known as tab panels—that are displayed one at a time. | [tabs.md](components/tabs.md) |
+| Textarea | Displays a form textarea or a component that looks like a textarea. | [textarea.md](components/textarea.md) |
+| Time Picker | A time picker component. | [time-picker.md](components/time-picker.md) |
+| Toast | A succinct message that is displayed temporarily. | [toast.md](components/toast.md) |
+| Tooltip | A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it. | [tooltip.md](components/tooltip.md) |
+
+## Usage Examples
+Examples are available at the bottom of each component page.
+
+### Basic Setup
+Here is a complete example of a Counter App using `shadcn_ui`, including light and dark theme support.
+```dart
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ShadApp(
+      debugShowCheckedModeBanner: false,
+      theme: ShadThemeData(
+        brightness: Brightness.light,
+        colorScheme: const ShadZincColorScheme.light(),
+      ),
+      darkTheme: ShadThemeData(
+        brightness: Brightness.dark,
+        colorScheme: const ShadZincColorScheme.dark(),
+      ),
+      themeMode: ThemeMode.system,
+      home: const CounterPage(),
+    );
+  }
+}
+
+class CounterPage extends StatefulWidget {
+  const CounterPage({super.key});
+
+  @override
+  State<CounterPage> createState() => _CounterPageState();
+}
+
+class _CounterPageState extends State<CounterPage> {
+  int _counter = 0;
+
+  void _incrementCounter() {
+    setState(() {
+      _counter++;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Shadcn Counter')),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              'You have pushed the button this many times:',
+              style: theme.textTheme.muted,
+            ),
+            Text(
+              '$_counter',
+              style: theme.textTheme.h1,
+            ),
+          ],
+        ),
+      ),
+      floatingActionButton: ShadButton(
+        onPressed: _incrementCounter,
+        child: const Icon(LucideIcons.plus),
+      ),
+    );
+  }
+}
+```
+
+## Packages included in the library
+
+Flutter Shadcn UI consists of fantastic open-source libraries that are exported and you can use them without importing them into your project.
+
+### [flutter_animate](https://pub.dev/packages/flutter_animate)
+
+The flutter animate library is a very cool animations library extensively used in Shadcn UI Components.
+
+With flutter_animate animations can be easily customized from the user, because components will take a `List<Effect>`.
+
+### [lucide_icons_flutter](https://pub.dev/packages/lucide_icons_flutter)
+
+A nice icon library that is used in Shadcn UI Components.
+You can use Lucide icons with the `LucideIcons` class, for example `LucideIcons.activity`.
+
+You can browse all the icons [here](https://lucide.dev/icons/).
+
+### [two_dimensional_scrollables](https://pub.dev/packages/two_dimensional_scrollables)
+
+A nice raw table (very performant) implementation used by the [ShadTable](../components/table) component.
+
+### [intl](https://pub.dev/packages/intl)
+
+The intl package provides internationalization and localization facilities, including message translation.
+
+### [universal_image](https://pub.dev/packages/universal_image)
+
+Support multiple image formats. Used by the [ShadAvatar](../components/avatar) component.

--- a/skills/shadcn-ui-flutter/components/accordion.md
+++ b/skills/shadcn-ui-flutter/components/accordion.md
@@ -1,0 +1,161 @@
+# Accordion
+
+A vertically stacked set of interactive headings that each reveal a section of content.
+
+
+
+```dart
+final details = [
+  (
+    title: 'Is it acceptable?',
+    content: 'Yes. It adheres to the WAI-ARIA design pattern.',
+  ),
+  (
+    title: 'Is it styled?',
+    content:
+        "Yes. It comes with default styles that matches the other components' aesthetic.",
+  ),
+  (
+    title: 'Is it animated?',
+    content:
+        "Yes. It's animated by default, but you can disable it if you prefer.",
+  ),
+];
+
+@override
+Widget build(BuildContext context) {
+  return ShadAccordion<({String content, String title})>(
+    children: details.map(
+      (detail) => ShadAccordionItem(
+        value: detail,
+        title: Text(detail.title),
+        child: Text(detail.content),
+      ),
+    ),
+  );
+}
+```
+
+
+
+## Multiple
+
+
+
+```dart
+final details = [
+  (
+    title: 'Is it acceptable?',
+    content: 'Yes. It adheres to the WAI-ARIA design pattern.',
+  ),
+  (
+    title: 'Is it styled?',
+    content:
+        "Yes. It comes with default styles that matches the other components' aesthetic.",
+  ),
+  (
+    title: 'Is it animated?',
+    content:
+        "Yes. It's animated by default, but you can disable it if you prefer.",
+  ),
+];
+
+@override
+Widget build(BuildContext context) {
+  return ShadAccordion<({String content, String title})>.multiple(
+    children: details.map(
+      (detail) => ShadAccordionItem(
+        value: detail,
+        title: Text(detail.title),
+        child: Text(detail.content),
+      ),
+    ),
+  );
+}
+```
+
+## Example
+```dart
+import 'package:example/common/base_scaffold.dart';
+import 'package:example/common/properties/bool_property.dart';
+import 'package:example/common/properties/enum_property.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+final details = [
+  (
+    title: 'Is it acceptable?',
+    content: 'Yes. It adheres to the WAI-ARIA design pattern.',
+  ),
+  (
+    title: 'Is it styled?',
+    content:
+        "Yes. It comes with default styles that matches the other components' aesthetic.",
+  ),
+  (
+    title: 'Is it animated?',
+    content:
+        "Yes. It's animated by default, but you can disable it if you prefer.",
+  ),
+];
+
+class AccordionPage extends StatefulWidget {
+  const AccordionPage({super.key});
+
+  @override
+  State<AccordionPage> createState() => _AccordionPageState();
+}
+
+class _AccordionPageState extends State<AccordionPage> {
+  var type = ShadAccordionVariant.single;
+  var underlineTitle = true;
+
+  @override
+  Widget build(BuildContext context) {
+    final children = details.map(
+      (detail) {
+        return ShadAccordionItem(
+          value: detail,
+          title: Text(detail.title),
+          underlineTitleOnHover: underlineTitle,
+          child: Text(detail.content),
+        );
+      },
+    );
+    return BaseScaffold(
+      appBarTitle: 'Accordion',
+      editable: [
+        MyEnumProperty(
+          label: 'Type',
+          value: type,
+          values: ShadAccordionVariant.values,
+          onChanged: (value) {
+            if (value != null) {
+              setState(() => type = value);
+            }
+          },
+        ),
+        MyBoolProperty(
+          label: 'Underline title',
+          value: underlineTitle,
+          onChanged: (v) => setState(() => underlineTitle = v),
+        ),
+      ],
+      children: [
+        ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 600),
+          child: type == ShadAccordionVariant.single
+              ? ShadAccordion<({String content, String title})>(
+                  children: children,
+                )
+              : ShadAccordion<({String content, String title})>.multiple(
+                  children: children,
+                ),
+        ),
+      ],
+    );
+  }
+}
+
+```

--- a/skills/shadcn-ui-flutter/components/alert.md
+++ b/skills/shadcn-ui-flutter/components/alert.md
@@ -1,0 +1,69 @@
+# Alert
+
+Displays a callout for user attention.
+
+
+
+```dart
+ShadAlert(
+  icon: Icon(LucideIcons.terminal),
+  title: Text('Heads up!'),
+  description:
+      Text('You can add components to your app using the cli.'),
+),
+```
+
+
+
+## Destructive
+
+
+
+```dart
+ShadAlert.destructive(
+  icon: Icon(LucideIcons.circleAlert),
+  title: Text('Error'),
+  description:
+      Text('Your session has expired. Please log in again.'),
+)
+```
+
+## Example
+```dart
+import 'package:example/common/base_scaffold.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class AlertPage extends StatelessWidget {
+  const AlertPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseScaffold(
+      appBarTitle: 'Alert',
+      children: [
+        ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 600),
+          child: const ShadAlert(
+            icon: Icon(LucideIcons.terminal),
+            title: Text('Heads up!'),
+            description: Text(
+              'You can add components to your app using the cli.',
+            ),
+          ),
+        ),
+        ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 600),
+          child: const ShadAlert.destructive(
+            icon: Icon(LucideIcons.circleAlert),
+            title: Text('Error'),
+            description: Text('Your session has expired. Please log in again.'),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+```

--- a/skills/shadcn-ui-flutter/components/avatar.md
+++ b/skills/shadcn-ui-flutter/components/avatar.md
@@ -1,0 +1,38 @@
+# Avatar
+
+An image element with a placeholder for representing the user.
+
+
+
+```dart
+ShadAvatar(
+  'https://app.requestly.io/delay/2000/avatars.githubusercontent.com/u/124599?v=4',
+  placeholder: Text('CN'),
+)
+```
+
+## Example
+```dart
+import 'package:example/common/base_scaffold.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class AvatarPage extends StatelessWidget {
+  const AvatarPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseScaffold(
+      appBarTitle: 'Avatar',
+      children: [
+        ShadAvatar(
+          'https://app.requestly.io/delay/2000/avatars.githubusercontent.com/u/124599?v=4&t=${DateTime.now().millisecondsSinceEpoch}',
+          placeholder: const Text('CN'),
+        ),
+      ],
+    );
+  }
+}
+
+```

--- a/skills/shadcn-ui-flutter/components/badge.md
+++ b/skills/shadcn-ui-flutter/components/badge.md
@@ -1,0 +1,74 @@
+# Badge
+
+Displays a badge or a component that looks like a badge.
+
+## Primary
+
+
+
+```dart
+ShadBadge(
+  child: const Text('Primary'),
+)
+```
+
+
+
+## Secondary
+
+
+
+```dart
+ShadBadge.secondary(
+  child: const Text('Secondary'),
+)
+```
+
+
+
+## Destructive
+
+
+
+```dart
+ShadBadge.destructive(
+  child: const Text('Destructive'),
+)
+```
+
+
+
+## Outline
+
+
+
+```dart
+ShadBadge.outline(
+  child: const Text('Outline'),
+)
+```
+
+## Example
+```dart
+import 'package:example/common/base_scaffold.dart';
+import 'package:flutter/material.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class BadgePage extends StatelessWidget {
+  const BadgePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const BaseScaffold(
+      appBarTitle: 'Badge',
+      children: [
+        ShadBadge(child: Text('Primary')),
+        ShadBadge.secondary(child: Text('Secondary')),
+        ShadBadge.destructive(child: Text('Destructive')),
+        ShadBadge.outline(child: Text('Outline')),
+      ],
+    );
+  }
+}
+
+```

--- a/skills/shadcn-ui-flutter/components/breadcrumb.md
+++ b/skills/shadcn-ui-flutter/components/breadcrumb.md
@@ -1,0 +1,287 @@
+# Breadcrumb
+
+Displays the path to the current resource using a hierarchy of links.
+
+
+
+
+```dart
+class PrimaryBreadcrumb extends StatelessWidget {
+  const PrimaryBreadcrumb({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ShadBreadcrumb(
+      children: [
+        ShadBreadcrumbLink(
+          onPressed: () => print('Navigating to Home'),
+          child: const Text('Home'),
+        ),
+        ShadBreadcrumbDropdown(
+          items: [
+            ShadBreadcrumbDropMenuItem(
+              onPressed: () => print('Navigating to Documentation'),
+              child: const Text('Documentation'),
+            ),
+            ShadBreadcrumbDropMenuItem(
+              onPressed: () => print('Navigating to Themes'),
+              child: const Text('Themes'),
+            ),
+            ShadBreadcrumbDropMenuItem(
+              onPressed: () => print('Navigating to Github'),
+              child: const Text('Github'),
+            ),
+          ],
+          showDropdownArrow: false,
+          child: ShadBreadcrumbEllipsis(),
+        ),
+        Text('Components'),
+        Text('Breadcrumb'),
+      ],
+    );
+  }
+}
+```
+
+
+
+## Custom separator
+
+Use a custom `separator` to change the default `>` separator.
+
+
+
+```dart
+class CustomSeparatorBreadcrumb extends StatelessWidget {
+  const CustomSeparatorBreadcrumb({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ShadBreadcrumb(
+      separator: const Icon(LucideIcons.slash),
+      children: [
+        ShadBreadcrumbLink(
+          onPressed: () => print('Navigating to Home'),
+          child: const Text('Home'),
+        ),
+        ShadBreadcrumbLink(
+          onPressed: () => print('Navigating to Components'),
+          child: const Text('Components'),
+        ),
+        Text('Breadcrumb'),
+      ],
+    );
+  }
+}
+```
+
+
+
+
+## Dropdown
+
+You can use `ShadBreadcrumbDropdown` to create a dropdown in the breadcrumb.
+
+
+
+```dart
+class DropdownBreadcrumb extends StatelessWidget {
+  const DropdownBreadcrumb({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ShadBreadcrumb(
+      children: [
+        ShadBreadcrumbLink(
+          onPressed: () => print('Navigating to Home'),
+          child: const Text('Home'),
+        ),
+        ShadBreadcrumbDropdown(
+          items: [
+            ShadBreadcrumbDropMenuItem(
+              onPressed: () => print('Navigating to Documentation'),
+              child: const Text('Documentation'),
+            ),
+            ShadBreadcrumbDropMenuItem(
+              onPressed: () => print('Navigating to Themes'),
+              child: const Text('Themes'),
+            ),
+            ShadBreadcrumbDropMenuItem(
+              onPressed: () => print('Navigating to Github'),
+              child: const Text('Github'),
+            ),
+          ],
+          child: const Text('Components'),
+        ),
+        Text('Breadcrumb'),
+      ],
+    );
+  }
+}
+```
+
+## Example
+```dart
+import 'package:flutter/material.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+import '../common/base_scaffold.dart';
+
+class BreadcrumbPage extends StatelessWidget {
+  const BreadcrumbPage({super.key});
+
+  void _navigateToHome() {
+    print('Navigating to Home');
+  }
+
+  void _navigateToComponents() {
+    print('Navigating to Components');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseScaffold(
+      appBarTitle: 'Breadcrumb',
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'Simple Breadcrumb',
+          style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+        ),
+        const ShadBreadcrumb(
+          children: [
+            Text('Home'),
+            Text('Library'),
+            Text('Data'),
+          ],
+        ),
+        const SizedBox(
+          height: 20,
+        ),
+        const Text(
+          'Breadcrumb with Links',
+          style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+        ),
+        ShadBreadcrumb(
+          children: [
+            ShadBreadcrumbLink(
+              onPressed: _navigateToHome,
+              child: const Text('Home'),
+            ),
+            ShadBreadcrumbLink(
+              onPressed: _navigateToComponents,
+              child: const Text('Components'),
+            ),
+            const Text('Breadcrumb'),
+          ],
+        ),
+        const SizedBox(
+          height: 20,
+        ),
+        const Text(
+          'Breadcrumb with Ellipsis',
+          style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+        ),
+        ShadBreadcrumb(
+          children: [
+            ShadBreadcrumbLink(
+              onPressed: _navigateToHome,
+              child: const Text('Home'),
+            ),
+            const ShadBreadcrumbEllipsis(),
+            ShadBreadcrumbLink(
+              onPressed: _navigateToComponents,
+              child: const Text('Components'),
+            ),
+            const Text('Breadcrumb'),
+          ],
+        ),
+        const SizedBox(height: 20),
+        const Text(
+          'Custom Separator',
+          style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+        ),
+        ShadBreadcrumb(
+          separator: const Icon(LucideIcons.slash),
+          children: [
+            ShadBreadcrumbLink(
+              onPressed: _navigateToHome,
+              child: const Text('Home'),
+            ),
+            ShadBreadcrumbLink(
+              onPressed: _navigateToComponents,
+              child: const Text('Components'),
+            ),
+            const Text('Breadcrumb'),
+          ],
+        ),
+        const SizedBox(
+          height: 20,
+        ),
+        const Text(
+          'Breadcrumb with Dropdown',
+          style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+        ),
+        ShadBreadcrumb(
+          children: [
+            ShadBreadcrumbLink(
+              onPressed: _navigateToHome,
+              child: const Text('Home'),
+            ),
+            ShadBreadcrumbDropdown(
+              items: [
+                ShadBreadcrumbDropMenuItem(
+                  onPressed: () => print('Navigating to Documentation'),
+                  child: const Text('Documentation'),
+                ),
+                ShadBreadcrumbDropMenuItem(
+                  onPressed: () => print('Navigating to Themes'),
+                  child: const Text('Themes'),
+                ),
+                ShadBreadcrumbDropMenuItem(
+                  onPressed: () => print('Navigating to Github'),
+                  child: const Text('Github'),
+                ),
+              ],
+              child: const Text('Components'),
+            ),
+            Text('Breadcrumb'),
+          ],
+        ),
+        const SizedBox(
+          height: 20,
+        ),
+        const Text(
+          'Long Breadcrumb',
+          style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+        ),
+        ShadBreadcrumb(
+          children: [
+            ShadBreadcrumbLink(
+              onPressed: _navigateToHome,
+              child: const Text('Home'),
+            ),
+            ShadBreadcrumbLink(
+              onPressed: _navigateToComponents,
+              child: const Text('Component 1'),
+            ),
+            ShadBreadcrumbLink(
+              onPressed: _navigateToComponents,
+              child: const Text('Component 2'),
+            ),
+            ShadBreadcrumbLink(
+              onPressed: _navigateToComponents,
+              child: const Text('Component 3'),
+            ),
+            ShadBreadcrumbLink(
+              onPressed: _navigateToComponents,
+              child: const Text('Component 4'),
+            ),
+            Text('Breadcrumb'),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+```

--- a/skills/shadcn-ui-flutter/components/button.md
+++ b/skills/shadcn-ui-flutter/components/button.md
@@ -1,0 +1,259 @@
+# Button
+
+Displays a button or a component that looks like a button.
+
+## Primary
+
+
+
+```dart
+ShadButton(
+  child: const Text('Primary'),
+  onPressed: () {},
+)
+```
+
+
+
+## Secondary
+
+
+
+```dart
+ShadButton.secondary(
+  child: const Text('Secondary'),
+  onPressed: () {},
+)
+```
+
+
+
+## Destructive
+
+
+
+```dart
+ShadButton.destructive(
+  child: const Text('Destructive'),
+  onPressed: () {},
+)
+```
+
+
+
+## Outline
+
+
+
+```dart
+ShadButton.outline(
+  child: const Text('Outline'),
+  onPressed: () {},
+)
+```
+
+
+
+## Ghost
+
+
+
+```dart
+ShadButton.ghost(
+  child: const Text('Ghost'),
+  onPressed: () {},
+)
+```
+
+
+
+## Link
+
+
+
+```dart
+ShadButton.link(
+  child: const Text('Link'),
+  onPressed: () {},
+)
+```
+
+
+
+## Text and Icon
+
+
+
+```dart
+ShadButton(
+  onPressed: () {},
+  leading: const Icon(LucideIcons.mail),
+  child: const Text('Login with Email'),
+)
+```
+
+
+
+## Loading
+
+
+
+```dart
+ShadButton(
+  onPressed: () {},
+  leading: SizedBox.square(
+    dimension: 16,
+    child: CircularProgressIndicator(
+      strokeWidth: 2,
+      color: ShadTheme.of(context).colorScheme.primaryForeground,
+    ),
+  ),
+  child: const Text('Please wait'),
+)
+```
+
+
+
+## Gradient and Shadow
+
+
+
+```dart
+ShadButton(
+  onPressed: () {},
+  gradient: const LinearGradient(colors: [
+    Colors.cyan,
+    Colors.indigo,
+  ]),
+  shadows: [
+    BoxShadow(
+      color: Colors.blue.withOpacity(.4),
+      spreadRadius: 4,
+      blurRadius: 10,
+      offset: const Offset(0, 2),
+    ),
+  ],
+  child: const Text('Gradient with Shadow'),
+)
+```
+
+## Example
+```dart
+import 'package:example/common/base_scaffold.dart';
+import 'package:example/common/properties/bool_property.dart';
+import 'package:example/common/properties/enum_property.dart';
+import 'package:flutter/material.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class ButtonPage extends StatefulWidget {
+  const ButtonPage({super.key});
+
+  @override
+  State<ButtonPage> createState() => _ButtonPageState();
+}
+
+class _ButtonPageState extends State<ButtonPage> {
+  var size = ShadButtonSize.regular;
+  var enabled = true;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return FocusTraversalGroup(
+      policy: WidgetOrderTraversalPolicy(),
+      child: BaseScaffold(
+        appBarTitle: 'Button',
+        editable: [
+          MyEnumProperty(
+            label: 'Size',
+            value: size,
+            values: ShadButtonSize.values,
+            onChanged: (value) {
+              if (value != null) {
+                setState(() => size = value);
+              }
+            },
+          ),
+          MyBoolProperty(
+            label: 'Enabled',
+            value: enabled,
+            onChanged: (value) => setState(() => enabled = value),
+          ),
+        ],
+        children: [
+          ShadButton(
+            size: size,
+            enabled: enabled,
+            child: const Text('Primary'),
+            onPressed: () => print('Primary'),
+          ),
+          ShadButton.secondary(
+            size: size,
+            enabled: enabled,
+            child: const Text('Secondary'),
+            onPressed: () => print('Secondary'),
+          ),
+          ShadButton.destructive(
+            size: size,
+            enabled: enabled,
+            child: const Text('Destructive'),
+          ),
+          ShadButton.outline(
+            size: size,
+            enabled: enabled,
+            child: const Text('Outline'),
+          ),
+          ShadButton.ghost(
+            size: size,
+            enabled: enabled,
+            child: const Text('Ghost'),
+          ),
+          ShadButton.link(
+            size: size,
+            enabled: enabled,
+            child: const Text('Link'),
+          ),
+          ShadButton(
+            size: size,
+            enabled: enabled,
+            leading: const Icon(LucideIcons.mail),
+            child: const Text('Login with Email'),
+          ),
+          ShadButton(
+            size: size,
+            enabled: enabled,
+            leading: SizedBox.square(
+              dimension: 16,
+              child: CircularProgressIndicator(
+                strokeWidth: 2,
+                color: theme.colorScheme.primaryForeground,
+              ),
+            ),
+            child: const Text('Please wait'),
+          ),
+          ShadButton(
+            size: size,
+            enabled: enabled,
+            gradient: const LinearGradient(
+              colors: [
+                Colors.cyan,
+                Colors.indigo,
+              ],
+            ),
+            shadows: [
+              BoxShadow(
+                color: Colors.blue.withValues(alpha: .4),
+                spreadRadius: 4,
+                blurRadius: 10,
+                offset: const Offset(0, 2),
+              ),
+            ],
+            child: const Text('Gradient with Shadow'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+```

--- a/skills/shadcn-ui-flutter/components/calendar.md
+++ b/skills/shadcn-ui-flutter/components/calendar.md
@@ -1,0 +1,326 @@
+# Calendar
+
+A date field component that allows users to enter and edit date.
+
+
+
+```dart
+class SingleCalendar extends StatefulWidget {
+  const SingleCalendar({super.key});
+
+  @override
+  State<SingleCalendar> createState() => _SingleCalendarState();
+}
+
+class _SingleCalendarState extends State<SingleCalendar> {
+  final today = DateTime.now();
+
+  @override
+  Widget build(BuildContext context) {
+    return ShadCalendar(
+      selected: today,
+      fromMonth: DateTime(today.year - 1),
+      toMonth: DateTime(today.year, 12),
+    );
+  }
+}
+```
+
+
+
+## Multiple
+
+
+
+```dart
+class MultipleCalendar extends StatefulWidget {
+ const MultipleCalendar({super.key});
+
+ @override
+ State<MultipleCalendar> createState() => _MultipleCalendarState();
+}
+
+class _MultipleCalendarState extends State<MultipleCalendar> {
+ final today = DateTime.now();
+
+ @override
+ Widget build(BuildContext context) {
+   return ShadCalendar.multiple(
+     numberOfMonths: 2,
+     fromMonth: DateTime(today.year),
+     toMonth: DateTime(today.year + 1, 12),
+     min: 5,
+     max: 10,
+   );
+ }
+}
+```
+
+
+
+## Range
+
+
+
+```dart
+class RangeCalendar extends StatelessWidget {
+ const RangeCalendar({super.key});
+
+ @override
+ Widget build(BuildContext context) {
+   return const ShadCalendar.range(
+     min: 2,
+     max: 5,
+   );
+ }
+}
+```
+
+
+
+#### DropdownMonths
+
+
+
+```dart
+ShadCalendar(
+  captionLayout: ShadCalendarCaptionLayout.dropdownMonths,
+);
+```
+
+
+
+#### DropdownYears
+
+
+
+```dart
+ShadCalendar(
+  captionLayout: ShadCalendarCaptionLayout.dropdownYears,
+);
+```
+
+
+
+### Hide Navigation
+
+
+
+```dart
+ShadCalendar(
+  hideNavigation: true,
+);
+```
+
+
+
+### Show Week Numbers
+
+
+
+```dart
+ShadCalendar(
+  showWeekNumbers: true,
+);
+```
+
+
+
+### Show Outside Days (false)
+
+
+
+```dart
+ShadCalendar(
+  showOutsideDays: false,
+);
+```
+
+
+
+### Fixed Weeks
+
+
+
+```dart
+ShadCalendar(
+  fixedWeeks: true,
+);
+```
+
+
+
+### Hide Weekday Names
+
+
+
+```dart
+ShadCalendar(
+  hideWeekdayNames: true,
+);
+```
+
+## Example
+```dart
+import 'package:example/common/base_scaffold.dart';
+import 'package:example/common/properties/bool_property.dart';
+import 'package:example/common/properties/enum_property.dart';
+import 'package:flutter/material.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class CalendarPage extends StatefulWidget {
+  const CalendarPage({super.key});
+
+  @override
+  State<CalendarPage> createState() => _CalendarPageState();
+}
+
+class _CalendarPageState extends State<CalendarPage> {
+  DateTime? selected = DateTime.now();
+  bool reverseMonths = false;
+  ShadCalendarCaptionLayout captionLayout = ShadCalendarCaptionLayout.label;
+  bool hideNavigation = false;
+  bool showWeekNumbers = false;
+  bool showOutsideDays = true;
+  bool fixedWeeks = false;
+  bool hideWeekdayNames = false;
+  bool allowDeselection = true;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return BaseScaffold(
+      appBarTitle: 'Calendar',
+      editable: [
+        MyBoolProperty(
+          label: 'Reverse months',
+          value: reverseMonths,
+          onChanged: (value) {
+            setState(() {
+              reverseMonths = value;
+            });
+          },
+        ),
+        MyEnumProperty(
+          label: 'Caption layout',
+          value: captionLayout,
+          values: ShadCalendarCaptionLayout.values,
+          onChanged: (value) {
+            if (value != null) {
+              setState(() {
+                captionLayout = value;
+              });
+            }
+          },
+        ),
+        MyBoolProperty(
+          label: 'Hide navigation',
+          value: hideNavigation,
+          onChanged: (value) {
+            setState(() {
+              hideNavigation = value;
+            });
+          },
+        ),
+        MyBoolProperty(
+          label: 'Show week numbers',
+          value: showWeekNumbers,
+          onChanged: (value) {
+            setState(() {
+              showWeekNumbers = value;
+            });
+          },
+        ),
+        MyBoolProperty(
+          label: 'Show outside days',
+          value: showOutsideDays,
+          enabled: !fixedWeeks,
+          onChanged: (value) {
+            setState(() {
+              showOutsideDays = value;
+            });
+          },
+        ),
+        MyBoolProperty(
+          label: 'Fixed weeks',
+          value: fixedWeeks,
+          enabled: showOutsideDays,
+          onChanged: (value) {
+            setState(() {
+              fixedWeeks = value;
+            });
+          },
+        ),
+        MyBoolProperty(
+          label: 'Hide weekday names',
+          value: hideWeekdayNames,
+          onChanged: (value) {
+            setState(() {
+              hideWeekdayNames = value;
+            });
+          },
+        ),
+        MyBoolProperty(
+          label: 'Allow deselection',
+          value: allowDeselection,
+          onChanged: (value) {
+            setState(() {
+              allowDeselection = value;
+            });
+          },
+        ),
+      ],
+      children: [
+        Text('Single', style: theme.textTheme.h4),
+        ShadCalendar(
+          selected: selected,
+          fromMonth: DateTime(2023),
+          toMonth: DateTime(2024, 12),
+          hideNavigation: hideNavigation,
+          captionLayout: captionLayout,
+          onMonthChanged: (date) {
+            print('month changed to ${date.month}');
+          },
+          showWeekNumbers: showWeekNumbers,
+          showOutsideDays: showOutsideDays,
+          fixedWeeks: fixedWeeks,
+          hideWeekdayNames: hideWeekdayNames,
+          allowDeselection: allowDeselection,
+        ),
+        const ShadSeparator.horizontal(),
+        Text('Multiple', style: theme.textTheme.h4),
+        ShadCalendar.multiple(
+          numberOfMonths: 2,
+          fromMonth: DateTime(2024),
+          toMonth: DateTime(2024, 12),
+          onChanged: (dates) {},
+          min: 5,
+          max: 10,
+          reverseMonths: reverseMonths,
+          hideNavigation: hideNavigation,
+          captionLayout: captionLayout,
+          showWeekNumbers: showWeekNumbers,
+          showOutsideDays: showOutsideDays,
+          fixedWeeks: fixedWeeks,
+          hideWeekdayNames: hideWeekdayNames,
+        ),
+        const ShadSeparator.horizontal(),
+        Text('Range', style: theme.textTheme.h4),
+        ShadCalendar.range(
+          onChanged: print,
+          min: 2,
+          max: 4,
+          hideNavigation: hideNavigation,
+          captionLayout: captionLayout,
+          showWeekNumbers: showWeekNumbers,
+          showOutsideDays: showOutsideDays,
+          fixedWeeks: fixedWeeks,
+          hideWeekdayNames: hideWeekdayNames,
+          allowDeselection: allowDeselection,
+        ),
+      ],
+    );
+  }
+}
+
+```

--- a/skills/shadcn-ui-flutter/components/card.md
+++ b/skills/shadcn-ui-flutter/components/card.md
@@ -1,0 +1,421 @@
+# Card
+
+Displays a card with header, content, and footer.
+
+
+
+```dart
+const frameworks = {
+  'next': 'Next.js',
+  'react': 'React',
+  'astro': 'Astro',
+  'nuxt': 'Nuxt.js',
+};
+
+class CardProject extends StatelessWidget {
+  const CardProject({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return ShadCard(
+      width: 350,
+      title: Text('Create project', style: theme.textTheme.h4),
+      description: const Text('Deploy your new project in one-click.'),
+      footer: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          ShadButton.outline(
+            child: const Text('Cancel'),
+            onPressed: () {},
+          ),
+          ShadButton(
+            child: const Text('Deploy'),
+            onPressed: () {},
+          ),
+        ],
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const Text('Name'),
+            const SizedBox(height: 6),
+            const ShadInput(placeholder: Text('Name of your project')),
+            const SizedBox(height: 16),
+            const Text('Framework'),
+            const SizedBox(height: 6),
+            ShadSelect<String>(
+              placeholder: const Text('Select'),
+              options: frameworks.entries
+                  .map((e) => ShadOption(value: e.key, child: Text(e.value)))
+                  .toList(),
+              selectedOptionBuilder: (context, value) {
+                return Text(frameworks[value]!);
+              },
+              onChanged: (value) {},
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+```
+
+
+
+## Notifications Example
+
+
+
+```dart
+
+
+
+const notifications = [
+  (
+    title: "Your call has been confirmed.",
+    description: "1 hour ago",
+  ),
+  (
+    title: "You have a new message!",
+    description: "1 hour ago",
+  ),
+  (
+    title: "Your subscription is expiring soon!",
+    description: "2 hours ago",
+  ),
+];
+
+class CardNotifications extends StatefulWidget {
+  const CardNotifications({super.key});
+
+  @override
+  State<CardNotifications> createState() => _CardNotificationsState();
+}
+
+class _CardNotificationsState extends State<CardNotifications> {
+  final pushNotifications = ValueNotifier(false);
+
+  @override
+  void dispose() {
+    pushNotifications.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return ShadCard(
+      width: 380,
+      title: const Text('Notifications'),
+      description: const Text('You have 3 unread messages.'),
+      footer: ShadButton(
+        width: double.infinity,
+        leading: const Padding(
+          padding: EdgeInsets.only(right: 8),
+          child: Icon(LucideIcons.check),
+        ),
+        onPressed: () {},
+        child: const Text('Mark all as read'),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const SizedBox(height: 16),
+          Container(
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              borderRadius: theme.radius,
+              border: Border.all(color: theme.colorScheme.border),
+            ),
+            child: Row(
+              children: [
+                Icon(
+                  LucideIcons.bellRing,
+                  size: 24,
+                  color: theme.colorScheme.foreground,
+                ),
+                Expanded(
+                  child: Padding(
+                    padding: const EdgeInsets.only(left: 16),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Push Notifications',
+                          style: theme.textTheme.small,
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          'Send notifications to device.',
+                          style: theme.textTheme.muted,
+                        )
+                      ],
+                    ),
+                  ),
+                ),
+                ValueListenableBuilder(
+                  valueListenable: pushNotifications,
+                  builder: (context, value, child) {
+                    return ShadSwitch(
+                      value: value,
+                      onChanged: (v) => pushNotifications.value = v,
+                    );
+                  },
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 16),
+          ...notifications
+              .map(
+                (n) => Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Container(
+                      width: 8,
+                      height: 8,
+                      margin: const EdgeInsets.only(top: 4),
+                      decoration: const BoxDecoration(
+                        color: Color(0xFF0CA5E9),
+                        shape: BoxShape.circle,
+                      ),
+                    ),
+                    Expanded(
+                      child: Padding(
+                        padding: const EdgeInsets.only(left: 16),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text('Your call has been confirmed.',
+                                style: theme.textTheme.small),
+                            const SizedBox(height: 4),
+                            Text(n.description, style: theme.textTheme.muted),
+                          ],
+                        ),
+                      ),
+                    )
+                  ],
+                ),
+              )
+              .separatedBy(const SizedBox(height: 16)),
+          const SizedBox(height: 16),
+        ],
+      ),
+    );
+  }
+}
+```
+
+## Example
+```dart
+import 'package:awesome_flutter_extensions/awesome_flutter_extensions.dart';
+import 'package:example/common/base_scaffold.dart';
+import 'package:flutter/material.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+const frameworks = {
+  'next': 'Next.js',
+  'react': 'React',
+  'astro': 'Astro',
+  'nuxt': 'Nuxt.js',
+};
+
+const notifications = [
+  (
+    title: "Your call has been confirmed.",
+    description: "1 hour ago",
+  ),
+  (
+    title: "You have a new message!",
+    description: "1 hour ago",
+  ),
+  (
+    title: "Your subscription is expiring soon!",
+    description: "2 hours ago",
+  ),
+];
+
+class CardPage extends StatefulWidget {
+  const CardPage({super.key});
+
+  @override
+  State<CardPage> createState() => _CardPageState();
+}
+
+class _CardPageState extends State<CardPage> {
+  final pushNotifications = ValueNotifier(false);
+
+  @override
+  void dispose() {
+    pushNotifications.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return BaseScaffold(
+      appBarTitle: 'Card',
+      children: [
+        ShadCard(
+          width: 350,
+          title: const Text('Create project'),
+          description: const Text('Deploy your new project in one-click.'),
+          footer: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              ShadButton.outline(
+                child: const Text('Cancel'),
+                onPressed: () {},
+              ),
+              ShadButton(
+                child: const Text('Deploy'),
+                onPressed: () {},
+              ),
+            ],
+          ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(vertical: 16),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                const Text('Name'),
+                const SizedBox(height: 6),
+                const ShadInput(placeholder: Text('Name of your project')),
+                const SizedBox(height: 16),
+                const Text('Framework'),
+                const SizedBox(height: 6),
+                ShadSelect<String>(
+                  placeholder: const Text('Select'),
+                  options: frameworks.entries
+                      .map(
+                        (e) => ShadOption(value: e.key, child: Text(e.value)),
+                      )
+                      .toList(),
+                  selectedOptionBuilder: (context, value) {
+                    return Text(frameworks[value]!);
+                  },
+                  onChanged: (value) {},
+                ),
+              ],
+            ),
+          ),
+        ),
+        const SizedBox(height: 40),
+        ShadCard(
+          width: 380,
+          title: const Text('Notifications'),
+          description: const Text('You have 3 unread messages.'),
+          footer: ShadButton(
+            width: double.infinity,
+            leading: const Padding(
+              padding: EdgeInsetsDirectional.only(end: 8),
+              child: Icon(LucideIcons.check),
+            ),
+            onPressed: () {},
+            child: const Text('Mark all as read'),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const SizedBox(height: 16),
+              Container(
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  borderRadius: theme.radius,
+                  border: Border.all(color: theme.colorScheme.border),
+                ),
+                child: Row(
+                  children: [
+                    Icon(
+                      LucideIcons.bellRing,
+                      size: 24,
+                      color: theme.colorScheme.foreground,
+                    ),
+                    Expanded(
+                      child: Padding(
+                        padding: const EdgeInsetsDirectional.only(start: 16),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              'Push Notifications',
+                              style: theme.textTheme.small,
+                            ),
+                            const SizedBox(height: 4),
+                            Text(
+                              'Send notifications to device.',
+                              style: theme.textTheme.muted,
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                    ValueListenableBuilder(
+                      valueListenable: pushNotifications,
+                      builder: (context, value, child) {
+                        return ShadSwitch(
+                          value: value,
+                          onChanged: (v) => pushNotifications.value = v,
+                        );
+                      },
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 16),
+              ...notifications
+                  .map(
+                    (n) => Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Container(
+                          width: 8,
+                          height: 8,
+                          margin: const EdgeInsets.only(top: 4),
+                          decoration: const BoxDecoration(
+                            color: Color(0xFF0CA5E9),
+                            shape: BoxShape.circle,
+                          ),
+                        ),
+                        Expanded(
+                          child: Padding(
+                            padding: const EdgeInsetsDirectional.only(
+                              start: 16,
+                            ),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  'Your call has been confirmed.',
+                                  style: theme.textTheme.small,
+                                ),
+                                const SizedBox(height: 4),
+                                Text(
+                                  n.description,
+                                  style: theme.textTheme.muted,
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  )
+                  .separatedBy(const SizedBox(height: 16)),
+              const SizedBox(height: 16),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+```

--- a/skills/shadcn-ui-flutter/components/checkbox.md
+++ b/skills/shadcn-ui-flutter/components/checkbox.md
@@ -1,0 +1,244 @@
+# Checkbox
+
+A control that allows the user to toggle between checked and not checked.
+
+
+
+```dart
+class CheckboxSample extends StatefulWidget {
+  const CheckboxSample({super.key});
+
+  @override
+  State<CheckboxSample> createState() => _CheckboxSampleState();
+}
+
+class _CheckboxSampleState extends State<CheckboxSample> {
+  bool value = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return ShadCheckbox(
+      value: value,
+      onChanged: (v) => setState(() => value = v),
+      label: const Text('Accept terms and conditions'),
+      sublabel: const Text(
+        'You agree to our Terms of Service and Privacy Policy.',
+      ),
+    );
+  }
+}
+```
+
+
+
+## Form
+
+
+
+```dart
+ShadCheckboxFormField(
+  id: 'terms',
+  initialValue: false,
+  inputLabel:
+      const Text('I accept the terms and conditions'),
+  onChanged: (v) {},
+  inputSublabel:
+      const Text('You agree to our Terms and Conditions'),
+  validator: (v) {
+    if (!v) {
+      return 'You must accept the terms and conditions';
+    }
+    return null;
+  },
+)
+```
+
+## Example
+```dart
+import 'package:example/common/base_scaffold.dart';
+import 'package:example/common/properties/bool_property.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class CheckboxPage extends StatefulWidget {
+  const CheckboxPage({super.key});
+
+  @override
+  State<CheckboxPage> createState() => _CheckboxPageState();
+}
+
+class _CheckboxPageState extends State<CheckboxPage> {
+  bool value = false;
+  bool enabled = true;
+  final focusNode = FocusNode();
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseScaffold(
+      appBarTitle: 'Checkbox',
+      editable: [
+        MyBoolProperty(
+          label: 'Enabled',
+          value: enabled,
+          onChanged: (value) => setState(() => enabled = value),
+        ),
+        MyBoolProperty(
+          label: 'Focused',
+          value: focusNode.hasFocus,
+          onChanged: enabled
+              ? (value) {
+                  setState(() {
+                    if (value) {
+                      focusNode.requestFocus();
+                    } else {
+                      focusNode.unfocus();
+                    }
+                  });
+                }
+              : null,
+        ),
+      ],
+      children: [
+        ShadCheckbox(
+          value: value,
+          focusNode: focusNode,
+          onChanged: (v) => setState(() => value = v),
+          enabled: enabled,
+          label: const Text('Accept terms and conditions'),
+          sublabel: const Text(
+            'You agree to our Terms of Service and Privacy Policy.',
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+```
+
+## Form Example
+```dart
+// ignore_for_file: avoid_print
+
+import 'dart:convert';
+
+import 'package:example/common/base_scaffold.dart';
+import 'package:example/common/properties/bool_property.dart';
+import 'package:example/common/properties/enum_property.dart';
+import 'package:flutter/material.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class CheckboxFormFieldPage extends StatefulWidget {
+  const CheckboxFormFieldPage({super.key});
+
+  @override
+  State<CheckboxFormFieldPage> createState() => _CheckboxFormFieldPageState();
+}
+
+class _CheckboxFormFieldPageState extends State<CheckboxFormFieldPage> {
+  bool enabled = true;
+  var autovalidateMode = ShadAutovalidateMode.alwaysAfterFirstValidation;
+  bool initialValue = false;
+  Map<Object, dynamic> formValue = {};
+  final formKey = GlobalKey<ShadFormState>();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return ShadForm(
+      key: formKey,
+      enabled: enabled,
+      autovalidateMode: autovalidateMode,
+      initialValue: {'terms': initialValue},
+      child: BaseScaffold(
+        appBarTitle: 'CheckboxFormField',
+        editable: [
+          MyBoolProperty(
+            label: 'Enabled',
+            value: enabled,
+            onChanged: (value) => setState(() => enabled = value),
+          ),
+          MyEnumProperty(
+            label: 'autovalidateMode',
+            value: autovalidateMode,
+            values: ShadAutovalidateMode.values,
+            onChanged: (value) {
+              if (value != null) {
+                setState(() => autovalidateMode = value);
+              }
+            },
+          ),
+          MyBoolProperty(
+            label: 'Form Initial Value',
+            value: initialValue,
+            onChanged: (value) {
+              formKey.currentState!.setFieldValue('terms', value);
+              setState(() {
+                initialValue = value;
+              });
+            },
+          ),
+        ],
+        children: [
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 350),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                ShadCheckboxFormField(
+                  id: 'terms',
+                  initialValue: initialValue,
+                  inputLabel: const Text('I accept the terms and conditions'),
+                  onChanged: print,
+                  inputSublabel: const Text(
+                    'You agree to our Terms and Conditions',
+                  ),
+                  validator: (v) {
+                    if (!v) {
+                      return 'You must accept the terms and conditions';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 16),
+                ShadButton(
+                  child: const Text('Submit'),
+                  onPressed: () {
+                    print('submitted');
+                    if (formKey.currentState!.saveAndValidate()) {
+                      setState(() {
+                        formValue = formKey.currentState!.value;
+                      });
+                    } else {
+                      print('validation failed');
+                    }
+                  },
+                ),
+                if (formValue.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 24, left: 12),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text('FormValue', style: theme.textTheme.p),
+                        const SizedBox(height: 4),
+                        SelectableText(
+                          const JsonEncoder.withIndent(
+                            '    ',
+                          ).convert(formValue),
+                          style: theme.textTheme.small,
+                        ),
+                      ],
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+```

--- a/skills/shadcn-ui-flutter/components/context-menu.md
+++ b/skills/shadcn-ui-flutter/components/context-menu.md
@@ -1,0 +1,195 @@
+# Context Menu
+
+Displays a menu to the user — such as a set of actions or functions — triggered by a mouse right-click.
+
+
+
+```dart
+
+
+
+class ContextMenuPage extends StatelessWidget {
+  const ContextMenuPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return Scaffold(
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: ShadContextMenuRegion(
+          constraints: const BoxConstraints(minWidth: 300),
+          items: [
+            const ShadContextMenuItem.inset(
+              child: Text('Back'),
+            ),
+            const ShadContextMenuItem.inset(
+              enabled: false,
+              child: Text('Forward'),
+            ),
+            const ShadContextMenuItem.inset(
+              child: Text('Reload'),
+            ),
+            const ShadContextMenuItem.inset(
+              trailing: Icon(LucideIcons.chevronRight),
+              items: [
+                ShadContextMenuItem(
+                  child: Text('Save Page As...'),
+                ),
+                ShadContextMenuItem(
+                  child: Text('Create Shortcut...'),
+                ),
+                ShadContextMenuItem(
+                  child: Text('Name Window...'),
+                ),
+                Divider(height: 8),
+                ShadContextMenuItem(
+                  child: Text('Developer Tools'),
+                ),
+              ],
+              child: Text('More Tools'),
+            ),
+            const Divider(height: 8),
+            const ShadContextMenuItem(
+              leading: Icon(LucideIcons.check),
+              child: Text('Show Bookmarks Bar'),
+            ),
+            const ShadContextMenuItem.inset(child: Text('Show Full URLs')),
+            const Divider(height: 8),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(36, 8, 8, 8),
+              child: Text('People', style: theme.textTheme.small),
+            ),
+            const Divider(height: 8),
+            ShadContextMenuItem(
+              leading: SizedBox.square(
+                dimension: 16,
+                child: Center(
+                  child: Container(
+                    width: 8,
+                    height: 8,
+                    decoration: BoxDecoration(
+                      color: theme.colorScheme.foreground,
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+                ),
+              ),
+              child: const Text('Pedro Duarte'),
+            ),
+            const ShadContextMenuItem.inset(child: Text('Colm Tuite')),
+          ],
+          child: Container(
+            width: 300,
+            height: 200,
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              border: Border.all(color: theme.colorScheme.border),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: const Text('Right click here'),
+          ),
+        ),
+      ),
+    );
+  }
+}
+```
+
+## Example
+```dart
+import 'package:example/common/base_scaffold.dart';
+import 'package:flutter/material.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class ContextMenuPage extends StatelessWidget {
+  const ContextMenuPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    const divider = ShadSeparator.horizontal(
+      margin: EdgeInsets.symmetric(vertical: 4),
+    );
+    return BaseScaffold(
+      appBarTitle: 'ContextMenu',
+      children: [
+        ShadContextMenuRegion(
+          constraints: const BoxConstraints(minWidth: 300),
+          items: [
+            const ShadContextMenuItem.inset(
+              child: Text('Back'),
+            ),
+            const ShadContextMenuItem.inset(
+              enabled: false,
+              child: Text('Forward'),
+            ),
+            const ShadContextMenuItem.inset(
+              child: Text('Reload'),
+            ),
+            const ShadContextMenuItem.inset(
+              trailing: Icon(LucideIcons.chevronRight),
+              items: [
+                ShadContextMenuItem(
+                  child: Text('Save Page As...'),
+                ),
+                ShadContextMenuItem(
+                  child: Text('Create Shortcut...'),
+                ),
+                ShadContextMenuItem(
+                  child: Text('Name Window...'),
+                ),
+                divider,
+                ShadContextMenuItem(
+                  child: Text('Developer Tools'),
+                ),
+              ],
+              child: Text('More Tools'),
+            ),
+            divider,
+            const ShadContextMenuItem(
+              leading: Icon(LucideIcons.check),
+              child: Text('Show Bookmarks Bar'),
+            ),
+            const ShadContextMenuItem.inset(child: Text('Show Full URLs')),
+            divider,
+            Padding(
+              padding: const EdgeInsets.fromLTRB(36, 8, 8, 8),
+              child: Text('People', style: theme.textTheme.small),
+            ),
+            divider,
+            ShadContextMenuItem(
+              leading: SizedBox.square(
+                dimension: 16,
+                child: Center(
+                  child: Container(
+                    width: 8,
+                    height: 8,
+                    decoration: BoxDecoration(
+                      color: theme.colorScheme.foreground,
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+                ),
+              ),
+              child: const Text('Pedro Duarte'),
+            ),
+            const ShadContextMenuItem.inset(child: Text('Colm Tuite')),
+          ],
+          child: Container(
+            width: 300,
+            height: 200,
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              border: Border.all(color: theme.colorScheme.border),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: const Text('Right click here'),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+```

--- a/skills/shadcn-ui-flutter/components/date-picker.md
+++ b/skills/shadcn-ui-flutter/components/date-picker.md
@@ -1,0 +1,383 @@
+# Date Picker
+
+A date picker component with range and presets.
+
+
+
+```dart
+class SingleDatePicker extends StatelessWidget {
+  const SingleDatePicker({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: 600),
+      child: const ShadDatePicker(),
+    );
+  }
+}
+```
+
+
+
+## Date Range Picker
+
+
+
+```dart
+class RangeDatePicker extends StatelessWidget {
+  const RangeDatePicker({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: 600),
+      child: const ShadDatePicker.range(),
+    );
+  }
+}
+```
+
+
+
+## With Presets
+
+
+
+```dart
+const presets = {
+  0: 'Today',
+  1: 'Tomorrow',
+  3: 'In 3 days',
+  7: 'In a week',
+};
+
+class PresetsDatePicker extends StatefulWidget {
+  const PresetsDatePicker({super.key});
+
+  @override
+  State<PresetsDatePicker> createState() => _PresetsDatePickerState();
+}
+
+class _PresetsDatePickerState extends State<PresetsDatePicker> {
+  final groupId = UniqueKey();
+  final today = DateTime.now().startOfDay;
+  DateTime? selected;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: 600),
+      child: ShadDatePicker(
+        // Using the same groupId to keep the date picker popover open when the
+        // select popover is closed.
+        groupId: groupId,
+        header: Padding(
+          padding: const EdgeInsets.only(bottom: 4),
+          child: ShadSelect<int>(
+            groupId: groupId,
+            minWidth: 276,
+            placeholder: const Text('Select'),
+            options: presets.entries
+                .map((e) => ShadOption(value: e.key, child: Text(e.value)))
+                .toList(),
+            selectedOptionBuilder: (context, value) {
+              return Text(presets[value]!);
+            },
+            onChanged: (value) {
+              if (value == null) return;
+              setState(() {
+                selected = today.add(Duration(days: value));
+              });
+            },
+          ),
+        ),
+        selected: selected,
+        calendarDecoration: theme.calendarTheme.decoration,
+        popoverPadding: const EdgeInsets.all(4),
+      ),
+    );
+  }
+}
+```
+
+
+
+## Form
+
+
+
+```dart
+ShadDatePickerFormField(
+  label: const Text('Date of birth'),
+  onChanged: print,
+  description: const Text(
+      'Your date of birth is used to calculate your age.'),
+  validator: (v) {
+    if (v == null) {
+      return 'A date of birth is required.';
+    }
+    return null;
+  },
+),
+```
+
+
+
+## DateRangePickerFormField
+
+
+
+```dart
+ShadDateRangePickerFormField(
+  label: const Text('Range of dates'),
+  onChanged: print,
+  description: const Text(
+      'Select the range of dates you want to search between.'),
+  validator: (v) {
+    if (v == null) return 'A range of dates is required.';
+    if (v.start == null) {
+      return 'The start date is required.';
+    }
+    if (v.end == null) return 'The end date is required.';
+
+    return null;
+  },
+),
+
+```
+
+## Example
+```dart
+import 'package:example/common/base_scaffold.dart';
+import 'package:example/common/properties/bool_property.dart';
+import 'package:flutter/material.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+const presets = {
+  0: 'Today',
+  1: 'Tomorrow',
+  3: 'In 3 days',
+  7: 'In a week',
+};
+
+class DatePickerPage extends StatefulWidget {
+  const DatePickerPage({super.key});
+
+  @override
+  State<DatePickerPage> createState() => _DatePickerPageState();
+}
+
+class _DatePickerPageState extends State<DatePickerPage> {
+  bool closeOnSelection = false;
+  bool allowDeselection = true;
+  final today = DateTime.now().startOfDay;
+  final groupId = UniqueKey();
+
+  DateTime? selected;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return BaseScaffold(
+      appBarTitle: 'DatePicker',
+      editable: [
+        MyBoolProperty(
+          label: 'closeOnSelection',
+          value: closeOnSelection,
+          onChanged: (value) => setState(() => closeOnSelection = value),
+        ),
+        MyBoolProperty(
+          label: 'allowDeselection',
+          value: allowDeselection,
+          onChanged: (value) => setState(() => allowDeselection = value),
+        ),
+      ],
+      children: [
+        Text('Single', style: theme.textTheme.h4),
+        ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 600),
+          child: ShadDatePicker(
+            closeOnSelection: closeOnSelection,
+            allowDeselection: allowDeselection,
+          ),
+        ),
+        const ShadSeparator.horizontal(),
+        Text('Range', style: theme.textTheme.h4),
+        ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 600),
+          child: ShadDatePicker.range(
+            closeOnSelection: closeOnSelection,
+            allowDeselection: allowDeselection,
+          ),
+        ),
+        const ShadSeparator.horizontal(),
+        Text('With Presets', style: theme.textTheme.h4),
+        ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 600),
+          child: ShadDatePicker(
+            // Using the same groupId to keep the date picker popover open when the
+            // select popover is closed.
+            groupId: groupId,
+            header: Padding(
+              padding: const EdgeInsets.only(bottom: 4),
+              child: ShadSelect<int>(
+                groupId: groupId,
+                minWidth: 276,
+                placeholder: const Text('Select'),
+                options: presets.entries
+                    .map((e) => ShadOption(value: e.key, child: Text(e.value)))
+                    .toList(),
+                selectedOptionBuilder: (context, value) {
+                  return Text(presets[value]!);
+                },
+                onChanged: (value) {
+                  if (value == null) return;
+                  setState(() {
+                    selected = today.add(Duration(days: value));
+                  });
+                },
+              ),
+            ),
+            closeOnSelection: closeOnSelection,
+            allowDeselection: allowDeselection,
+            selected: selected,
+            calendarDecoration: theme.calendarTheme.decoration,
+            popoverPadding: const EdgeInsets.all(4),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+```
+
+## Form Example
+```dart
+// ignore_for_file: avoid_print
+
+import 'package:example/common/base_scaffold.dart';
+import 'package:example/common/properties/bool_property.dart';
+import 'package:example/common/properties/enum_property.dart';
+import 'package:flutter/material.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class DatePickerFormFieldPage extends StatefulWidget {
+  const DatePickerFormFieldPage({super.key});
+
+  @override
+  State<DatePickerFormFieldPage> createState() =>
+      _DatePickerFormFieldPageState();
+}
+
+class _DatePickerFormFieldPageState extends State<DatePickerFormFieldPage> {
+  bool enabled = true;
+  var autovalidateMode = ShadAutovalidateMode.alwaysAfterFirstValidation;
+  Map<Object, dynamic> formValue = {};
+  final formKey = GlobalKey<ShadFormState>();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return ShadForm(
+      key: formKey,
+      enabled: enabled,
+      autovalidateMode: autovalidateMode,
+      child: BaseScaffold(
+        appBarTitle: 'DatePickerFormField',
+        editable: [
+          MyBoolProperty(
+            label: 'Enabled',
+            value: enabled,
+            onChanged: (value) => setState(() => enabled = value),
+          ),
+          MyEnumProperty(
+            label: 'autovalidateMode',
+            value: autovalidateMode,
+            values: ShadAutovalidateMode.values,
+            onChanged: (value) {
+              if (value != null) {
+                setState(() => autovalidateMode = value);
+              }
+            },
+          ),
+        ],
+        children: [
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 350),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('Single', style: theme.textTheme.h4),
+                ShadDatePickerFormField(
+                  id: 'date',
+                  label: const Text('Date of birth'),
+                  onChanged: print,
+                  description: const Text(
+                    'Your date of birth is used to calculate your age.',
+                  ),
+                  validator: (v) {
+                    if (v == null) {
+                      return 'A date of birth is required.';
+                    }
+                    return null;
+                  },
+                ),
+                const ShadSeparator.horizontal(),
+                Text('Range', style: theme.textTheme.h4),
+                ShadDateRangePickerFormField(
+                  id: 'range-date',
+                  label: const Text('Range of dates'),
+                  onChanged: print,
+                  description: const Text(
+                    'Select the range of dates you want to search between.',
+                  ),
+                  validator: (v) {
+                    if (v == null) return 'A range of dates is required.';
+                    if (v.start == null) return 'The start date is required.';
+                    if (v.end == null) return 'The end date is required.';
+
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 16),
+                ShadButton(
+                  child: const Text('Submit'),
+                  onPressed: () {
+                    print('submitted');
+                    if (formKey.currentState!.saveAndValidate()) {
+                      setState(() {
+                        formValue = formKey.currentState!.value;
+                      });
+                    } else {
+                      print('validation failed');
+                    }
+                  },
+                ),
+                if (formValue.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 24, left: 12),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text('FormValue', style: theme.textTheme.p),
+                        const SizedBox(height: 4),
+                        SelectableText(
+                          formValue.toString(),
+                          style: theme.textTheme.small,
+                        ),
+                      ],
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+```

--- a/skills/shadcn-ui-flutter/components/dialog.md
+++ b/skills/shadcn-ui-flutter/components/dialog.md
@@ -1,0 +1,240 @@
+# Dialog
+
+A modal dialog that interrupts the user.
+
+
+
+```dart
+
+
+final profile = [
+  (title: 'Name', value: 'Alexandru'),
+  (title: 'Username', value: 'nank1ro'),
+];
+
+class DialogExample extends StatelessWidget {
+  const DialogExample({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return ShadButton.outline(
+      child: const Text('Edit Profile'),
+      onPressed: () {
+        showShadDialog(
+          context: context,
+          builder: (context) => ShadDialog(
+            title: const Text('Edit Profile'),
+            description: const Text(
+                "Make changes to your profile here. Click save when you're done"),
+            actions: const [ShadButton(child: Text('Save changes'))],
+            child: Container(
+              width: 375,
+              padding: const EdgeInsets.symmetric(vertical: 20),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.end,
+                spacing: 16,
+                children: profile
+                    .map(
+                      (p) => Row(
+                        children: [
+                          Expanded(
+                            child: Text(
+                              p.title,
+                              textAlign: TextAlign.end,
+                              style: theme.textTheme.small,
+                            ),
+                          ),
+                          const SizedBox(width: 16),
+                          Expanded(
+                            flex: 3,
+                            child: ShadInput(initialValue: p.value),
+                          ),
+                        ],
+                      ),
+                    ).toList(),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+```
+
+
+
+## Alert
+
+
+
+```dart
+class DialogExample extends StatelessWidget {
+  const DialogExample({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ShadButton.outline(
+      child: const Text('Show Dialog'),
+      onPressed: () {
+        showShadDialog(
+          context: context,
+          builder: (context) => ShadDialog.alert(
+            title: const Text('Are you absolutely sure?'),
+            description: const Padding(
+              padding: EdgeInsets.only(bottom: 8),
+              child: Text(
+                'This action cannot be undone. This will permanently delete your account and remove your data from our servers.',
+              ),
+            ),
+            actions: [
+              ShadButton.outline(
+                child: const Text('Cancel'),
+                onPressed: () => Navigator.of(context).pop(false),
+              ),
+              ShadButton(
+                child: const Text('Continue'),
+                onPressed: () => Navigator.of(context).pop(true),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+```
+
+## Example
+```dart
+import 'package:example/common/base_scaffold.dart';
+import 'package:example/common/properties/bool_property.dart';
+import 'package:flutter/material.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+final profile = [
+  (title: 'Name', value: 'Alexandru'),
+  (title: 'Username', value: 'nank1ro'),
+];
+
+class DialogPage extends StatefulWidget {
+  const DialogPage({super.key});
+
+  @override
+  State<DialogPage> createState() => _DialogPageState();
+}
+
+class _DialogPageState extends State<DialogPage> {
+  var titlePinned = false;
+  var descriptionPinned = false;
+  var actionsPinned = true;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return BaseScaffold(
+      appBarTitle: 'Dialog',
+      editable: [
+        MyBoolProperty(
+          label: 'titlePinned',
+          value: titlePinned,
+          onChanged: (v) => setState(() => titlePinned = v),
+        ),
+        MyBoolProperty(
+          label: 'descriptionPinned',
+          value: descriptionPinned,
+          onChanged: (v) => setState(() => descriptionPinned = v),
+        ),
+        MyBoolProperty(
+          label: 'actionsPinned',
+          value: actionsPinned,
+          onChanged: (v) => setState(() => actionsPinned = v),
+        ),
+      ],
+      children: [
+        ShadButton.outline(
+          child: const Text('Edit Profile'),
+          onPressed: () {
+            showShadDialog(
+              context: context,
+              builder: (context) => ShadDialog(
+                title: const Text('Edit Profile'),
+                description: const Text(
+                  "Make changes to your profile here. Click save when you're done",
+                ),
+                actions: const [ShadButton(child: Text('Save changes'))],
+                titlePinned: titlePinned,
+                descriptionPinned: descriptionPinned,
+                actionsPinned: actionsPinned,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                child: Container(
+                  width: 375,
+                  padding: const EdgeInsets.symmetric(vertical: 20),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    spacing: 16,
+                    children: profile
+                        .map(
+                          (p) => Row(
+                            children: [
+                              Expanded(
+                                child: Text(
+                                  p.title,
+                                  textAlign: TextAlign.end,
+                                  style: theme.textTheme.small,
+                                ),
+                              ),
+                              const SizedBox(width: 16),
+                              Expanded(
+                                flex: 3,
+                                child: ShadInput(initialValue: p.value),
+                              ),
+                            ],
+                          ),
+                        )
+                        .toList(),
+                  ),
+                ),
+              ),
+            );
+          },
+        ),
+        ShadButton.outline(
+          child: const Text('Show Dialog'),
+          onPressed: () {
+            showShadDialog(
+              context: context,
+              builder: (context) => ShadDialog.alert(
+                title: const Text('Are you absolutely sure?'),
+                titlePinned: titlePinned,
+                descriptionPinned: descriptionPinned,
+                actionsPinned: actionsPinned,
+                description: const Padding(
+                  padding: EdgeInsets.only(bottom: 8),
+                  child: Text(
+                    'This action cannot be undone. This will permanently delete your account and remove your data from our servers.',
+                  ),
+                ),
+                actions: [
+                  ShadButton.outline(
+                    child: const Text('Cancel'),
+                    onPressed: () => Navigator.of(context).pop(false),
+                  ),
+                  ShadButton(
+                    child: const Text('Continue'),
+                    onPressed: () => Navigator.of(context).pop(true),
+                  ),
+                ],
+              ),
+            );
+          },
+        ),
+      ],
+    );
+  }
+}
+
+```

--- a/skills/shadcn-ui-flutter/components/form.md
+++ b/skills/shadcn-ui-flutter/components/form.md
@@ -1,0 +1,292 @@
+# Form
+
+Builds a form with validation and easy access to form fields values.
+
+The benefits of using `ShadForm` over managing form fields individually are:
+- Centralized form state management.
+- Easy access to all form field values as a single `Map<String, dynamic>`.
+- No need to manage individual controllers for each form field.
+
+
+
+```dart
+class FormPage extends StatefulWidget {
+  const FormPage({
+    super.key,
+  });
+
+  @override
+  State<FormPage> createState() => _FormPageState();
+}
+
+class _FormPageState extends State<FormPage> {
+  final formKey = GlobalKey<ShadFormState>();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: ShadForm(
+          key: formKey,
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 350),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                ShadInputFormField(
+                  id: 'username',
+                  label: const Text('Username'),
+                  placeholder: const Text('Enter your username'),
+                  description: const Text('This is your public display name.'),
+                  validator: (v) {
+                    if (v.length < 2) {
+                      return 'Username must be at least 2 characters.';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 16),
+                ShadButton(
+                  child: const Text('Submit'),
+                  onPressed: () {
+                    if (formKey.currentState!.saveAndValidate()) {
+                      print(
+                          'validation succeeded with ${formKey.currentState!.value}');
+                    } else {
+                      print('validation failed');
+                    }
+                  },
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+```
+
+
+
+## Initial form value
+
+You can set the initial form value by passing a `Map<String, dynamic>` to the `initialValue` property of the `ShadForm` widget.
+
+```dart {2-5}
+ShadForm(
+  initialValue: {
+    'username': 'john_doe',
+    'email': 'john_doe@example.com'
+  },
+  child: // Your form fields here
+)
+```
+
+All form fields with matching `id`s will be initialized with the corresponding values from the `initialValue` map.
+Unless they have their own `initialValue` set.
+
+## Get the form value
+
+You can get the current form value by accessing the `value` property of `ShadFormState` using a `GlobalKey`.
+
+```dart {8-10}
+final formKey = GlobalKey<ShadFormState>();
+
+// Your Form widget
+ShadForm(
+  key: formKey,
+),
+
+// To get the form value
+final formValue = formKey.currentState!.value; // Returns a Map<String, dynamic> with the form field values
+```
+
+You typically need this after getting a successful value from the `saveAndValidate` method, for example:
+```dart {4-8}
+ShadButton(
+  child: const Text('Submit'),
+  onPressed: () {
+    final formState = formKey.currentState!;
+    // The form is not valid, return early
+    if (!formState.saveAndValidate()) return;
+    // The form is valid, print the form value
+    print('Form value: ${formState.value}');
+  },
+),
+```
+
+## Manipulate single form field value
+
+You can set or update the value of specific form fields using the `setFieldValue` method of `ShadFormState`.
+
+```dart {8-10}
+final formKey = GlobalKey<ShadFormState>();
+
+// Your Form widget
+ShadForm(
+  key: formKey,
+),
+
+// To set or update a specific field value
+formKey.currentState!.setFieldValue('username', 'new_username');
+```
+
+If you don't want to notify the field about the value change, you can pass `notifyField: false` as argument.
+This would only update the form value without updating the field UI.
+
+## Manipulate entire form value
+
+You can set or update the entire form value using the `setValue` method of `ShadFormState`.
+
+```dart {8-12}
+final formKey = GlobalKey<ShadFormState>();
+
+// Your Form widget
+ShadForm(
+  key: formKey,
+),
+
+// To set or update the entire form value
+formKey.currentState!.setValue({
+  'username': 'new_username',
+  'email': 'example@email.com'
+});
+```
+
+If you don't want to notify the fields about the value change, you can pass `notifyFields: false` as argument.
+This would only update the form value without updating the fields UI.
+
+## Value transformers
+
+You can use value transformers to convert the initial value from the form to the field value and vice versa.
+
+### fromValueTransformer
+
+If your `ShadForm` has an initial value like this one `{'date': '2024-02-01'}` and you need to convert the string value to a `DateTime` object for a `ShadDatePickerFormField`:
+```dart {3}
+ShadDatePickerFormField(
+  id: 'date',
+  fromValueTransformer: (value) => DateTime.tryParse(value ?? ''),
+),
+```
+
+Vice versa, you can use the `toValueTransformer` parameter to convert the field value back to the form value.
+```dart {3-5}
+ShadDatePickerFormField(
+  id: 'date',
+  toValueTransformer: (date) => date == null
+      ? null
+      : DateFormat('yyyy-MM-dd').format(date),
+),
+```
+
+In this way, the form field can work with `DateTime` objects while the form value remains a `String` both as initial value (input) and when getting the form value (output).
+
+## Dot notation for nested values
+
+By default, `ShadForm` supports dot notation in field IDs to automatically create nested map structures. This makes it easier to work with complex, hierarchical form data.
+
+### How it works
+
+When you use field IDs with dots (like `user.email` or `profile.settings.theme`), the form automatically converts them into nested maps:
+
+```dart
+ShadForm(
+  child: Column(
+    children: [
+      ShadInputFormField(
+        id: 'user.name',
+        label: const Text('Name'),
+      ),
+      ShadInputFormField(
+        id: 'user.email',
+        label: const Text('Email'),
+      ),
+      ShadInputFormField(
+        id: 'user.age',
+        label: const Text('Age'),
+      ),
+    ],
+  ),
+)
+```
+
+When you retrieve the form value, it will be structured as:
+```dart
+{
+  'user': {
+    'name': 'John Doe',
+    'email': 'john@example.com',
+    'age': '30'
+  }
+}
+```
+
+### Initial values with nested structure
+
+The `initialValue` should be provided as a nested map structure (not using dot notation):
+
+```dart
+ShadForm(
+  initialValue: {
+    'user': {
+      'name': 'John Doe',
+      'email': 'john@example.com',
+    },
+  },
+  child: // Your form fields with dot notation IDs
+)
+```
+
+The form will automatically extract values from the nested structure based on the field IDs. For example, a field with `id: 'user.name'` will get the value from `initialValue['user']['name']`.
+
+### Customizing the separator
+
+If you prefer a different separator, you can customize it using the `fieldIdSeparator` parameter:
+
+```dart {2}
+ShadForm(
+  fieldIdSeparator: '/',
+  child: Column(
+    children: [
+      ShadInputFormField(
+        id: 'user/name', // Using '/' instead of '.'
+        label: const Text('Name'),
+      ),
+    ],
+  ),
+)
+```
+
+### Disabling dot notation
+
+If you want to use dots in your field IDs without creating nested structures, you can disable the feature by setting `fieldIdSeparator` to `null`:
+
+```dart {2}
+ShadForm(
+  fieldIdSeparator: null,
+  child: Column(
+    children: [
+      ShadInputFormField(
+        id: 'user.email', // This will remain as a flat key
+        label: const Text('Email'),
+      ),
+    ],
+  ),
+)
+```
+
+## Examples
+
+See the following links for more examples on how to use the `ShadForm` component with other components:
+
+- [Checkbox](../checkbox#form)
+- [Switch](../switch#form)
+- [Input](../input#form)
+- [Select](../select#form)
+- [RadioGroup](../radio-group#form)
+- [DatePicker](../date-picker#form)
+- [TimePicker](../time-picker#form)
+

--- a/skills/shadcn-ui-flutter/components/icon-button.md
+++ b/skills/shadcn-ui-flutter/components/icon-button.md
@@ -1,0 +1,201 @@
+# IconButton
+
+Displays an icon button or a component that looks like a button with an icon.
+
+## Primary
+
+
+
+```dart
+ShadIconButton(
+  onPressed: () => print('Primary'),
+  icon: const Icon(LucideIcons.rocket),
+)
+```
+
+
+
+## Secondary
+
+
+
+```dart
+ShadIconButton.secondary(
+  icon: const Icon(LucideIcons.rocket),
+  onPressed: () => print('Secondary'),
+)
+```
+
+
+
+## Destructive
+
+
+
+```dart
+ShadIconButton.destructive(
+  icon: const Icon(LucideIcons.rocket),
+  onPressed: () => print('Destructive'),
+)
+```
+
+
+
+## Outline
+
+
+
+```dart
+ShadIconButton.outline(
+  icon: const Icon(LucideIcons.rocket),
+  onPressed: () => print('Outline'),
+)
+```
+
+
+
+## Ghost
+
+
+
+```dart
+ShadIconButton.ghost(
+  icon: const Icon(LucideIcons.rocket),
+  onPressed: () => print('Ghost'),
+)
+```
+
+
+
+## Loading
+
+
+
+```dart
+ShadIconButton(
+  icon: SizedBox.square(
+    dimension: 16,
+    child: CircularProgressIndicator(
+      strokeWidth: 2,
+      color: ShadTheme.of(context).colorScheme.primaryForeground,
+    ),
+  ),
+)
+```
+
+
+
+## Gradient and Shadow
+
+
+
+```dart
+ShadIconButton(
+  gradient: const LinearGradient(colors: [
+    Colors.cyan,
+    Colors.indigo,
+  ]),
+  shadows: [
+    BoxShadow(
+      color: Colors.blue.withValues(alpha: .4),
+      spreadRadius: 4,
+      blurRadius: 10,
+      offset: const Offset(0, 2),
+    ),
+  ],
+  icon: const Icon(LucideIcons.rocket),
+)
+```
+
+## Example
+```dart
+import 'package:example/common/base_scaffold.dart';
+import 'package:example/common/properties/bool_property.dart';
+import 'package:flutter/material.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class IconButtonPage extends StatefulWidget {
+  const IconButtonPage({super.key});
+
+  @override
+  State<IconButtonPage> createState() => _IconButtonPageState();
+}
+
+class _IconButtonPageState extends State<IconButtonPage> {
+  var enabled = true;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return FocusTraversalGroup(
+      policy: WidgetOrderTraversalPolicy(),
+      child: BaseScaffold(
+        appBarTitle: 'IconButton',
+        editable: [
+          MyBoolProperty(
+            label: 'Enabled',
+            value: enabled,
+            onChanged: (value) => setState(() => enabled = value),
+          ),
+        ],
+        children: [
+          ShadIconButton(
+            enabled: enabled,
+            onPressed: () => print('Primary'),
+            icon: const Icon(LucideIcons.rocket),
+          ),
+          ShadIconButton.secondary(
+            enabled: enabled,
+            icon: const Icon(LucideIcons.rocket),
+            onPressed: () => print('Secondary'),
+          ),
+          ShadIconButton.destructive(
+            enabled: enabled,
+            icon: const Icon(LucideIcons.rocket),
+            onPressed: () => print('Destructive'),
+          ),
+          ShadIconButton.outline(
+            enabled: enabled,
+            icon: const Icon(LucideIcons.rocket),
+            onPressed: () => print('Outline'),
+          ),
+          ShadIconButton.ghost(
+            enabled: enabled,
+            icon: const Icon(LucideIcons.rocket),
+            onPressed: () => print('Ghost'),
+          ),
+          ShadIconButton(
+            enabled: enabled,
+            gradient: const LinearGradient(
+              colors: [
+                Colors.cyan,
+                Colors.indigo,
+              ],
+            ),
+            shadows: [
+              BoxShadow(
+                color: Colors.blue.withValues(alpha: .4),
+                spreadRadius: 4,
+                blurRadius: 10,
+                offset: const Offset(0, 2),
+              ),
+            ],
+            icon: const Icon(LucideIcons.rocket),
+          ),
+          ShadIconButton(
+            enabled: enabled,
+            icon: SizedBox.square(
+              dimension: 16,
+              child: CircularProgressIndicator(
+                strokeWidth: 2,
+                color: theme.colorScheme.primaryForeground,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+```

--- a/skills/shadcn-ui-flutter/components/input-otp.md
+++ b/skills/shadcn-ui-flutter/components/input-otp.md
@@ -1,0 +1,334 @@
+# InputOTP
+
+Accessible one-time password component with copy paste functionality.
+
+
+
+```dart
+ShadInputOTP(
+  onChanged: (v) => print('OTP: $v'),
+  maxLength: 6,
+  children: const [
+    ShadInputOTPGroup(
+      children: [
+        ShadInputOTPSlot(),
+        ShadInputOTPSlot(),
+        ShadInputOTPSlot(),
+      ],
+    ),
+    Icon(size: 24, LucideIcons.dot),
+    ShadInputOTPGroup(
+      children: [
+        ShadInputOTPSlot(),
+        ShadInputOTPSlot(),
+        ShadInputOTPSlot(),
+      ],
+    ),
+  ],
+)
+```
+
+
+
+## InputFormatters
+
+Using InputFormatters you can restrict the input characters.
+The example below shows how to restrict the input to only numbers.
+
+
+
+```dart
+ShadInputOTP(
+  onChanged: (v) => print('OTP: $v'),
+  maxLength: 4,
+  keyboardType: TextInputType.number,
+  inputFormatters: [
+    FilteringTextInputFormatter.digitsOnly,
+  ],
+  children: const [
+    ShadInputOTPGroup(
+      children: [
+        ShadInputOTPSlot(),
+        ShadInputOTPSlot(),
+        ShadInputOTPSlot(),
+        ShadInputOTPSlot(),
+      ],
+    ),
+  ],
+)
+```
+
+
+
+See also `UpperCaseTextInputFormatter` and `LowerCaseTextInputFormatter` which are provided by the package.
+
+## Form
+
+
+
+```dart
+ShadInputOTPFormField(
+  id: 'otp',
+  maxLength: 6,
+  label: const Text('OTP'),
+  description: const Text('Enter your OTP.'),
+  validator: (v) {
+    if (v.contains(' ')) {
+      return 'Fill the whole OTP code';
+    }
+    return null;
+  },
+  children: const [
+    ShadInputOTPGroup(
+      children: [
+        ShadInputOTPSlot(),
+        ShadInputOTPSlot(),
+        ShadInputOTPSlot(),
+      ],
+    ),
+    Icon(size: 24, LucideIcons.dot),
+    ShadInputOTPGroup(
+      children: [
+        ShadInputOTPSlot(),
+        ShadInputOTPSlot(),
+        ShadInputOTPSlot(),
+      ],
+    ),
+  ],
+)
+```
+
+## Example
+```dart
+import 'package:example/common/base_scaffold.dart';
+import 'package:example/common/properties/bool_property.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class InputOTPPage extends StatefulWidget {
+  const InputOTPPage({super.key});
+
+  @override
+  State<InputOTPPage> createState() => _InputOTPPageState();
+}
+
+class _InputOTPPageState extends State<InputOTPPage> {
+  var enabled = true;
+  var uppercase = true;
+  var digitsOnly = false;
+  var jumpToNextWhenFilled = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseScaffold(
+      appBarTitle: 'Input OTP',
+      editable: [
+        MyBoolProperty(
+          label: 'Enabled',
+          value: enabled,
+          onChanged: (value) => setState(() => enabled = value),
+        ),
+        MyBoolProperty(
+          label: 'Uppercase',
+          value: uppercase,
+          enabled: !digitsOnly,
+          onChanged: (value) => setState(() => uppercase = value),
+        ),
+        MyBoolProperty(
+          label: 'Digits only',
+          value: digitsOnly,
+          enabled: !uppercase,
+          onChanged: (value) => setState(() => digitsOnly = value),
+        ),
+        MyBoolProperty(
+          label: 'Jump to next when filled',
+          value: jumpToNextWhenFilled,
+          onChanged: (value) => setState(() => jumpToNextWhenFilled = value),
+        ),
+      ],
+      children: [
+        ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 600),
+          child: ShadInputOTP(
+            onChanged: (v) => print('OTP: $v'),
+            maxLength: 6,
+            enabled: enabled,
+            jumpToNextWhenFilled: jumpToNextWhenFilled,
+            keyboardType: digitsOnly ? TextInputType.number : null,
+            inputFormatters: [
+              if (digitsOnly) FilteringTextInputFormatter.digitsOnly,
+              if (uppercase) const UpperCaseTextInputFormatter(),
+            ],
+            children: const [
+              ShadInputOTPGroup(
+                children: [
+                  ShadInputOTPSlot(),
+                  ShadInputOTPSlot(),
+                  ShadInputOTPSlot(),
+                ],
+              ),
+              Icon(LucideIcons.dot),
+              ShadInputOTPGroup(
+                children: [
+                  ShadInputOTPSlot(),
+                  ShadInputOTPSlot(),
+                  ShadInputOTPSlot(),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+```
+
+## Form Example
+```dart
+// ignore_for_file: avoid_print
+
+import 'dart:convert';
+
+import 'package:example/common/base_scaffold.dart';
+import 'package:example/common/properties/bool_property.dart';
+import 'package:example/common/properties/enum_property.dart';
+import 'package:example/common/properties/string_property.dart';
+import 'package:flutter/material.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class InputOTPFormFieldPage extends StatefulWidget {
+  const InputOTPFormFieldPage({super.key});
+
+  @override
+  State<InputOTPFormFieldPage> createState() => _InputOTPFormFieldPageState();
+}
+
+class _InputOTPFormFieldPageState extends State<InputOTPFormFieldPage> {
+  bool enabled = true;
+  var autovalidateMode = ShadAutovalidateMode.alwaysAfterFirstValidation;
+  String? initialValue;
+  Map<Object, dynamic> formValue = {};
+  final formKey = GlobalKey<ShadFormState>();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return ShadForm(
+      key: formKey,
+      enabled: enabled,
+      autovalidateMode: autovalidateMode,
+      initialValue: {if (initialValue != null) 'otp': initialValue},
+      child: BaseScaffold(
+        appBarTitle: 'InputFormField',
+        editable: [
+          MyBoolProperty(
+            label: 'Enabled',
+            value: enabled,
+            onChanged: (value) => setState(() => enabled = value),
+          ),
+          MyEnumProperty(
+            label: 'autovalidateMode',
+            value: autovalidateMode,
+            values: ShadAutovalidateMode.values,
+            onChanged: (value) {
+              if (value != null) {
+                setState(() => autovalidateMode = value);
+              }
+            },
+          ),
+          MyStringProperty(
+            label: 'Form Initial Value',
+            initialValue: initialValue,
+            placeholder: const Text('OTP initial value'),
+            onChanged: (value) {
+              setState(() {
+                value.isEmpty ? initialValue = null : initialValue = value;
+              });
+              // Reset the form
+              WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+                formKey.currentState!.reset();
+              });
+            },
+          ),
+        ],
+        children: [
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 350),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                ShadInputOTPFormField(
+                  id: 'otp',
+                  maxLength: 6,
+                  enabled: enabled,
+                  label: const Text('OTP'),
+                  description: const Text('Enter your OTP.'),
+                  validator: (v) {
+                    if (v.contains(' ')) {
+                      return 'Fill the whole OTP code';
+                    }
+                    return null;
+                  },
+                  children: const [
+                    ShadInputOTPGroup(
+                      children: [
+                        ShadInputOTPSlot(),
+                        ShadInputOTPSlot(),
+                        ShadInputOTPSlot(),
+                      ],
+                    ),
+                    Icon(LucideIcons.dot),
+                    ShadInputOTPGroup(
+                      children: [
+                        ShadInputOTPSlot(),
+                        ShadInputOTPSlot(),
+                        ShadInputOTPSlot(),
+                      ],
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                ShadButton(
+                  child: const Text('Submit'),
+                  onPressed: () {
+                    print('submitted');
+                    if (formKey.currentState!.saveAndValidate()) {
+                      setState(() {
+                        formValue = formKey.currentState!.value;
+                      });
+                    } else {
+                      print('validation failed');
+                    }
+                  },
+                ),
+                if (formValue.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 24, left: 12),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text('FormValue', style: theme.textTheme.p),
+                        const SizedBox(height: 4),
+                        SelectableText(
+                          const JsonEncoder.withIndent(
+                            '    ',
+                          ).convert(formValue),
+                          style: theme.textTheme.small,
+                        ),
+                      ],
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+```

--- a/skills/shadcn-ui-flutter/components/input.md
+++ b/skills/shadcn-ui-flutter/components/input.md
@@ -1,0 +1,283 @@
+# Input
+
+Displays a form input field or a component that looks like an input field.
+
+
+
+```dart
+ConstrainedBox(
+  constraints: const BoxConstraints(maxWidth: 320),
+  child: const ShadInput(
+    placeholder: Text('Email'),
+    keyboardType: TextInputType.emailAddress,
+  ),
+),
+```
+
+
+
+## With leading and trailing
+
+
+
+```dart
+class PasswordInput extends StatefulWidget {
+  const PasswordInput({super.key});
+
+  @override
+  State<PasswordInput> createState() => _PasswordInputState();
+}
+
+class _PasswordInputState extends State<PasswordInput> {
+  bool obscure = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return ShadInput(
+      placeholder: const Text('Password'),
+      obscureText: obscure,
+      leading: Icon(LucideIcons.lock),
+      trailing: SizedBox.square(
+        dimension: 24,
+        child: OverflowBox(
+          maxWidth: 28,
+          maxHeight: 28,
+          child: ShadIconButton(
+            iconSize: 20,
+            padding: EdgeInsets.all(2),
+            icon: Icon(obscure ? LucideIcons.eyeOff : LucideIcons.eye),
+            onPressed: () {
+              setState(() => obscure = !obscure);
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}
+```
+
+
+
+## Form
+
+
+
+```dart
+ShadInputFormField(
+  id: 'username',
+  label: const Text('Username'),
+  placeholder: const Text('Enter your username'),
+  description:
+      const Text('This is your public display name.'),
+  validator: (v) {
+    if (v.length < 2) {
+      return 'Username must be at least 2 characters.';
+    }
+    return null;
+  },
+),
+```
+
+## Example
+```dart
+import 'package:example/common/base_scaffold.dart';
+import 'package:example/common/properties/bool_property.dart';
+import 'package:flutter/material.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class InputPage extends StatefulWidget {
+  const InputPage({super.key});
+
+  @override
+  State<InputPage> createState() => _InputPageState();
+}
+
+class _InputPageState extends State<InputPage> {
+  bool enabled = true;
+  bool obscure = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseScaffold(
+      appBarTitle: 'Input',
+      editable: [
+        MyBoolProperty(
+          label: 'Enabled',
+          value: enabled,
+          onChanged: (value) => setState(() => enabled = value),
+        ),
+        MyBoolProperty(
+          label: 'Obscure',
+          value: obscure,
+          onChanged: (value) => setState(() => obscure = value),
+        ),
+      ],
+      children: [
+        ShadInput(
+          placeholder: const Text('Email'),
+          enabled: enabled,
+          keyboardType: TextInputType.emailAddress,
+        ),
+        ShadInput(
+          placeholder: const Text('Password'),
+          enabled: enabled,
+          obscureText: obscure,
+          leading: Icon(LucideIcons.lock),
+          trailing: SizedBox.square(
+            dimension: 24,
+            child: OverflowBox(
+              maxWidth: 28,
+              maxHeight: 28,
+              child: ShadIconButton(
+                iconSize: 20,
+                padding: EdgeInsets.all(2),
+                icon: Icon(obscure ? LucideIcons.eyeOff : LucideIcons.eye),
+                onPressed: () {
+                  setState(() => obscure = !obscure);
+                },
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+```
+
+## Form Example
+```dart
+import 'dart:convert';
+import 'package:example/common/base_scaffold.dart';
+import 'package:example/common/properties/bool_property.dart';
+import 'package:example/common/properties/enum_property.dart';
+import 'package:example/common/properties/string_property.dart';
+import 'package:flutter/material.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class InputFormFieldPage extends StatefulWidget {
+  const InputFormFieldPage({super.key});
+
+  @override
+  State<InputFormFieldPage> createState() => _InputFormFieldPageState();
+}
+
+class _InputFormFieldPageState extends State<InputFormFieldPage> {
+  bool enabled = true;
+  var autovalidateMode = ShadAutovalidateMode.alwaysAfterFirstValidation;
+  String? initialValue;
+  Map<Object, dynamic> formValue = {};
+  final formKey = GlobalKey<ShadFormState>();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return ShadForm(
+      key: formKey,
+      enabled: enabled,
+      autovalidateMode: autovalidateMode,
+      initialValue: {
+        if (initialValue != null) 'username': initialValue,
+        'profile': {'age': 18},
+      },
+      child: BaseScaffold(
+        appBarTitle: 'InputFormField',
+        editable: [
+          MyBoolProperty(
+            label: 'Enabled',
+            value: enabled,
+            onChanged: (value) => setState(() => enabled = value),
+          ),
+          MyEnumProperty(
+            label: 'autovalidateMode',
+            value: autovalidateMode,
+            values: ShadAutovalidateMode.values,
+            onChanged: (value) {
+              if (value != null) {
+                setState(() => autovalidateMode = value);
+              }
+            },
+          ),
+          MyStringProperty(
+            label: 'Form Initial Value',
+            initialValue: initialValue,
+            placeholder: const Text('Name'),
+            onChanged: (value) {
+              formKey.currentState!.setFieldValue('username', value);
+            },
+          ),
+        ],
+        children: [
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 350),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              spacing: 16,
+              children: [
+                ShadInputFormField(
+                  id: 'username',
+                  leading: const Icon(LucideIcons.user),
+                  label: const Text('Username'),
+                  placeholder: const Text('Enter your username'),
+                  description: const Text('This is your public display name.'),
+                  validator: (v) {
+                    if (v.length < 2) {
+                      return 'Username must be at least 2 characters.';
+                    }
+                    return null;
+                  },
+                ),
+                ShadInputFormField(
+                  id: 'profile.age',
+                  fromValueTransformer: (v) => v?.toString(),
+                  toValueTransformer: (String? v) => int.tryParse(v ?? ''),
+                  keyboardType: TextInputType.number,
+                  label: const Text('Age (dot notation)'),
+                  placeholder: const Text('Enter your age'),
+                  description: const Text(
+                    'This field uses dot notation: profile.age',
+                  ),
+                ),
+                ShadButton(
+                  child: const Text('Submit'),
+                  onPressed: () {
+                    print('submitted');
+                    if (formKey.currentState!.saveAndValidate()) {
+                      setState(() {
+                        formValue = formKey.currentState!.value;
+                      });
+                    } else {
+                      print('validation failed');
+                    }
+                  },
+                ),
+
+                if (formValue.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 24, left: 12),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text('FormValue', style: theme.textTheme.p),
+                        const SizedBox(height: 4),
+                        SelectableText(
+                          const JsonEncoder.withIndent(
+                            '    ',
+                          ).convert(formValue),
+                          style: theme.textTheme.small,
+                        ),
+                      ],
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+```

--- a/skills/shadcn-ui-flutter/components/menubar.md
+++ b/skills/shadcn-ui-flutter/components/menubar.md
@@ -1,0 +1,262 @@
+# Menubar
+
+A visually persistent menu common in desktop applications that provides quick access to a consistent set of commands.
+
+
+
+```dart
+class MenubarExample extends StatelessWidget {
+  const MenubarExample({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    final square = SizedBox.square(
+      dimension: 16,
+      child: Center(
+        child: SizedBox.square(
+          dimension: 8,
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: theme.colorScheme.foreground,
+              shape: BoxShape.circle,
+            ),
+          ),
+        ),
+      ),
+    );
+    final divider = ShadSeparator.horizontal(
+      margin: const EdgeInsets.symmetric(vertical: 4),
+      color: theme.colorScheme.muted,
+    );
+    return ShadMenubar(
+      items: [
+        ShadMenubarItem(
+          items: [
+            const ShadContextMenuItem(child: Text('New Tab')),
+            const ShadContextMenuItem(child: Text('New Window')),
+            const ShadContextMenuItem(
+              enabled: false,
+              child: Text('New Incognito Window'),
+            ),
+            divider,
+            const ShadContextMenuItem(
+              trailing: Icon(LucideIcons.chevronRight),
+              items: [
+                ShadContextMenuItem(child: Text('Email Link')),
+                ShadContextMenuItem(child: Text('Messages')),
+                ShadContextMenuItem(child: Text('Notes')),
+              ],
+              child: Text('Share'),
+            ),
+            divider,
+            const ShadContextMenuItem(child: Text('Print...')),
+          ],
+          child: const Text('File'),
+        ),
+        ShadMenubarItem(
+          items: [
+            const ShadContextMenuItem(child: Text('Undo')),
+            const ShadContextMenuItem(child: Text('Redo')),
+            divider,
+            ShadContextMenuItem(
+              trailing: const Icon(LucideIcons.chevronRight),
+              items: [
+                const ShadContextMenuItem(child: Text('Search the web')),
+                divider,
+                const ShadContextMenuItem(child: Text('Find...')),
+                const ShadContextMenuItem(child: Text('Find Next')),
+                const ShadContextMenuItem(child: Text('Find Previous')),
+              ],
+              child: const Text('Find'),
+            ),
+            divider,
+            const ShadContextMenuItem(child: Text('Cut')),
+            const ShadContextMenuItem(child: Text('Copy')),
+            const ShadContextMenuItem(child: Text('Paste')),
+          ],
+          child: const Text('Edit'),
+        ),
+        ShadMenubarItem(
+          items: [
+            const ShadContextMenuItem.inset(
+              child: Text('Always Show Bookmarks Bar'),
+            ),
+            const ShadContextMenuItem(
+              leading: Icon(LucideIcons.check),
+              child: Text('Always Show Full URLs'),
+            ),
+            divider,
+            const ShadContextMenuItem.inset(child: Text('Reload')),
+            const ShadContextMenuItem.inset(
+                enabled: false, child: Text('Force Reload')),
+            divider,
+            const ShadContextMenuItem.inset(
+              child: Text('Toggle Full Screen'),
+            ),
+            divider,
+            const ShadContextMenuItem.inset(child: Text('Hide Sidebar')),
+          ],
+          child: const Text('View'),
+        ),
+        ShadMenubarItem(items: [
+          const ShadContextMenuItem.inset(child: Text('Andy')),
+          ShadContextMenuItem(leading: square, child: const Text('Benoit')),
+          const ShadContextMenuItem.inset(child: Text('Luis')),
+          divider,
+          const ShadContextMenuItem.inset(child: Text('Edit...')),
+          divider,
+          const ShadContextMenuItem.inset(child: Text('Add Profile...')),
+        ], child: const Text('Profiles')),
+      ],
+    );
+  }
+}
+```
+
+## Example
+```dart
+import 'package:example/common/base_scaffold.dart';
+import 'package:example/common/properties/bool_property.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class MenubarPage extends StatefulWidget {
+  const MenubarPage({super.key});
+
+  @override
+  State<MenubarPage> createState() => _MenubarPageState();
+}
+
+class _MenubarPageState extends State<MenubarPage> {
+  var selectOnHover = true;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    final square = SizedBox.square(
+      dimension: 16,
+      child: Center(
+        child: SizedBox.square(
+          dimension: 8,
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: theme.colorScheme.foreground,
+              shape: BoxShape.circle,
+            ),
+          ),
+        ),
+      ),
+    );
+    final divider = ShadSeparator.horizontal(
+      margin: const EdgeInsets.symmetric(vertical: 4),
+      color: theme.colorScheme.muted,
+    );
+
+    return BaseScaffold(
+      appBarTitle: 'Menubar',
+      editable: [
+        MyBoolProperty(
+          label: 'Select on hover',
+          value: selectOnHover,
+          onChanged: (value) => setState(() => selectOnHover = value),
+        ),
+      ],
+      children: [
+        ShadMenubar(
+          selectOnHover: selectOnHover,
+          items: [
+            ShadMenubarItem(
+              items: [
+                const ShadContextMenuItem(child: Text('New Tab')),
+                const ShadContextMenuItem(child: Text('New Window')),
+                const ShadContextMenuItem(
+                  enabled: false,
+                  child: Text('New Incognito Window'),
+                ),
+                divider,
+                const ShadContextMenuItem(
+                  trailing: Icon(LucideIcons.chevronRight),
+                  items: [
+                    ShadContextMenuItem(child: Text('Email Link')),
+                    ShadContextMenuItem(child: Text('Messages')),
+                    ShadContextMenuItem(child: Text('Notes')),
+                  ],
+                  child: Text('Share'),
+                ),
+                divider,
+                const ShadContextMenuItem(child: Text('Print...')),
+              ],
+              child: const Text('File'),
+            ),
+            ShadMenubarItem(
+              items: [
+                const ShadContextMenuItem(child: Text('Undo')),
+                const ShadContextMenuItem(child: Text('Redo')),
+                divider,
+                ShadContextMenuItem(
+                  trailing: const Icon(LucideIcons.chevronRight),
+                  items: [
+                    const ShadContextMenuItem(child: Text('Search the web')),
+                    divider,
+                    const ShadContextMenuItem(child: Text('Find...')),
+                    const ShadContextMenuItem(child: Text('Find Next')),
+                    const ShadContextMenuItem(child: Text('Find Previous')),
+                  ],
+                  child: const Text('Find'),
+                ),
+                divider,
+                const ShadContextMenuItem(child: Text('Cut')),
+                const ShadContextMenuItem(child: Text('Copy')),
+                const ShadContextMenuItem(child: Text('Paste')),
+              ],
+              child: const Text('Edit'),
+            ),
+            ShadMenubarItem(
+              items: [
+                const ShadContextMenuItem.inset(
+                  child: Text('Always Show Bookmarks Bar'),
+                ),
+                const ShadContextMenuItem(
+                  leading: Icon(LucideIcons.check),
+                  child: Text('Always Show Full URLs'),
+                ),
+                divider,
+                const ShadContextMenuItem.inset(child: Text('Reload')),
+                const ShadContextMenuItem.inset(
+                  enabled: false,
+                  child: Text('Force Reload'),
+                ),
+                divider,
+                const ShadContextMenuItem.inset(
+                  child: Text('Toggle Full Screen'),
+                ),
+                divider,
+                const ShadContextMenuItem.inset(child: Text('Hide Sidebar')),
+              ],
+              child: const Text('View'),
+            ),
+            ShadMenubarItem(
+              items: [
+                const ShadContextMenuItem.inset(child: Text('Andy')),
+                ShadContextMenuItem(
+                  leading: square,
+                  child: const Text('Benoit'),
+                ),
+                const ShadContextMenuItem.inset(child: Text('Luis')),
+                divider,
+                const ShadContextMenuItem.inset(child: Text('Edit...')),
+                divider,
+                const ShadContextMenuItem.inset(child: Text('Add Profile...')),
+              ],
+              child: const Text('Profiles'),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+```

--- a/skills/shadcn-ui-flutter/components/popover.md
+++ b/skills/shadcn-ui-flutter/components/popover.md
@@ -1,0 +1,178 @@
+# Popover
+
+Displays rich content in a portal, triggered by a button.
+
+
+
+```dart
+
+
+
+
+class PopoverPage extends StatefulWidget {
+  const PopoverPage({super.key});
+
+  @override
+  State<PopoverPage> createState() => _PopoverPageState();
+}
+
+class _PopoverPageState extends State<PopoverPage> {
+  final popoverController = ShadPopoverController();
+
+  final List<({String name, String initialValue})> layer = [
+    (name: 'Width', initialValue: '100%'),
+    (name: 'Max. width', initialValue: '300px'),
+    (name: 'Height', initialValue: '25px'),
+    (name: 'Max. height', initialValue: 'none'),
+  ];
+
+  @override
+  void dispose() {
+    popoverController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = ShadTheme.of(context).textTheme;
+    return Scaffold(
+      body: Center(
+        child: ShadPopover(
+          controller: popoverController,
+          popover: (context) => SizedBox(
+            width: 288,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  'Dimensions',
+                  style: textTheme.h4,
+                ),
+                Text(
+                  'Set the dimensions for the layer.',
+                  style: textTheme.p,
+                ),
+                const SizedBox(height: 4),
+                ...layer
+                    .map(
+                      (e) => Row(
+                        mainAxisAlignment: MainAxisAlignment.start,
+                        children: [
+                          Expanded(
+                              child: Text(
+                            e.name,
+                            textAlign: TextAlign.start,
+                          )),
+                          Expanded(
+                            flex: 2,
+                            child: ShadInput(
+                              initialValue: e.initialValue,
+                            ),
+                          )
+                        ],
+                      ),
+                    )
+                    .separatedBy(const SizedBox(height: 8)),
+              ],
+            ),
+          ),
+          child: ShadButton.outline(
+            onPressed: popoverController.toggle,
+            child: const Text('Open popover'),
+          ),
+        ),
+      ),
+    );
+  }
+}
+```
+
+## Example
+```dart
+import 'package:awesome_flutter_extensions/awesome_flutter_extensions.dart';
+import 'package:example/common/base_scaffold.dart';
+import 'package:flutter/material.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class PopoverPage extends StatefulWidget {
+  const PopoverPage({super.key});
+
+  @override
+  State<PopoverPage> createState() => _PopoverPageState();
+}
+
+class _PopoverPageState extends State<PopoverPage> {
+  final popoverController = ShadPopoverController();
+
+  final List<({String name, String initialValue})> layer = [
+    (name: 'Width', initialValue: '100%'),
+    (name: 'Max. width', initialValue: '300px'),
+    (name: 'Height', initialValue: '25px'),
+    (name: 'Max. height', initialValue: 'none'),
+  ];
+
+  @override
+  void dispose() {
+    popoverController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = ShadTheme.of(context).textTheme;
+    return BaseScaffold(
+      appBarTitle: 'Popover',
+      children: [
+        ShadPopover(
+          controller: popoverController,
+          popover: (_) => SizedBox(
+            width: 288,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  'Dimensions',
+                  style: textTheme.h4,
+                ),
+                Text(
+                  'Set the dimensions for the layer.',
+                  style: textTheme.p,
+                ),
+                const SizedBox(height: 4),
+                ...layer
+                    .map(
+                      (e) => Row(
+                        mainAxisAlignment: MainAxisAlignment.start,
+                        children: [
+                          Expanded(
+                            child: Text(
+                              e.name,
+                              textAlign: TextAlign.start,
+                            ),
+                          ),
+                          Expanded(
+                            flex: 2,
+                            child: ShadInput(
+                              initialValue: e.initialValue,
+                            ),
+                          ),
+                        ],
+                      ),
+                    )
+                    .separatedBy(const SizedBox(height: 8)),
+              ],
+            ),
+          ),
+          child: ShadButton.outline(
+            onPressed: popoverController.toggle,
+            child: const Text('Open popover'),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+```

--- a/skills/shadcn-ui-flutter/components/progress.md
+++ b/skills/shadcn-ui-flutter/components/progress.md
@@ -1,0 +1,77 @@
+# Progress
+
+Displays an indicator showing the completion progress of a task, typically displayed as a progress bar.
+
+## Determinate
+
+
+ ```dart
+ConstrainedBox(
+  constraints: BoxConstraints(
+    maxWidth: MediaQuery.sizeOf(context).width * 0.6,
+  ),
+  child: const ShadProgress(value: 0.5),
+),
+```
+
+
+
+## Indeterminate
+
+ ```dart
+ConstrainedBox(
+  constraints: BoxConstraints(
+    maxWidth: MediaQuery.sizeOf(context).width * 0.6,
+  ),
+  child: const ShadProgress(),
+),
+```
+
+## Example
+```dart
+import 'package:example/common/base_scaffold.dart';
+import 'package:flutter/material.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class ProgressPage extends StatefulWidget {
+  const ProgressPage({super.key});
+
+  @override
+  State<ProgressPage> createState() => _ProgressPageState();
+}
+
+class _ProgressPageState extends State<ProgressPage> {
+  var value = 50;
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseScaffold(
+      appBarTitle: 'Progress',
+      children: [
+        Text('Determinate Progress'),
+        ShadProgress(
+          value: value / 100,
+        ),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            ShadIconButton.ghost(
+              enabled: value != 0,
+              onPressed: () => setState(() => value -= 10),
+              icon: const Icon(Icons.remove),
+            ),
+            ShadIconButton.ghost(
+              enabled: value != 100,
+              onPressed: () => setState(() => value += 10),
+              icon: const Icon(Icons.add),
+            ),
+          ],
+        ),
+        Text('Indeterminate Progress'),
+        ShadProgress(),
+      ],
+    );
+  }
+}
+
+```

--- a/skills/shadcn-ui-flutter/components/radio-group.md
+++ b/skills/shadcn-ui-flutter/components/radio-group.md
@@ -1,0 +1,284 @@
+# RadioGroup
+
+A set of checkable buttons—known as radio buttons—where no more than one of the buttons can be checked at a time.
+
+
+
+```dart
+ShadRadioGroup<String>(
+  items: [
+    ShadRadio(
+      label: Text('Default'),
+      value: 'default',
+    ),
+    ShadRadio(
+      label: Text('Comfortable'),
+      value: 'comfortable',
+    ),
+    ShadRadio(
+      label: Text('Nothing'),
+      value: 'nothing',
+    ),
+  ],
+),
+```
+
+
+
+## Form
+
+
+
+```dart
+enum NotifyAbout {
+  all,
+  mentions,
+  nothing;
+
+  String get message {
+    return switch (this) {
+      all => 'All new messages',
+      mentions => 'Direct messages and mentions',
+      nothing => 'Nothing',
+    };
+  }
+}
+
+ShadRadioGroupFormField<NotifyAbout>(
+  label: const Text('Notify me about'),
+  items: NotifyAbout.values.map(
+    (e) => ShadRadio(
+      value: e,
+      label: Text(e.message),
+    ),
+  ),
+  validator: (v) {
+    if (v == null) {
+      return 'You need to select a notification type.';
+    }
+    return null;
+  },
+),
+```
+
+## Example
+```dart
+import 'package:example/common/base_scaffold.dart';
+import 'package:example/common/properties/bool_property.dart';
+import 'package:example/common/properties/enum_property.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+enum NotifyAbout {
+  all,
+  mentions,
+  nothing;
+
+  String get message {
+    return switch (this) {
+      all => 'All new messages',
+      mentions => 'Direct messages and mentions',
+      nothing => 'Nothing',
+    };
+  }
+}
+
+class RadioPage extends StatefulWidget {
+  const RadioPage({super.key});
+
+  @override
+  State<RadioPage> createState() => _RadioPageState();
+}
+
+class _RadioPageState extends State<RadioPage> {
+  NotifyAbout? value;
+  bool enabled = true;
+  Axis axis = Axis.vertical;
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseScaffold(
+      appBarTitle: 'RadioGroup',
+      crossAxisAlignment: CrossAxisAlignment.start,
+      editable: [
+        MyBoolProperty(
+          label: 'Enabled',
+          value: enabled,
+          onChanged: (value) => setState(() => enabled = value),
+        ),
+        MyEnumProperty(
+          label: 'Axis',
+          value: axis,
+          onChanged: (value) {
+            if (value != null) {
+              setState(() => axis = value);
+            }
+          },
+          values: Axis.values,
+        ),
+      ],
+      children: [
+        ShadRadioGroup<NotifyAbout>(
+          enabled: enabled,
+          initialValue: value,
+          onChanged: (v) {
+            print('onChange $v');
+          },
+          axis: axis,
+          items: NotifyAbout.values.map(
+            (e) => ShadRadio(
+              value: e,
+              label: Text(e.message),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+```
+
+## Form Example
+```dart
+// ignore_for_file: avoid_print
+
+import 'dart:convert';
+
+import 'package:example/common/base_scaffold.dart';
+import 'package:example/common/properties/bool_property.dart';
+import 'package:example/common/properties/enum_property.dart';
+import 'package:flutter/material.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+enum NotifyAbout {
+  all,
+  mentions,
+  nothing;
+
+  String get message {
+    return switch (this) {
+      all => 'All new messages',
+      mentions => 'Direct messages and mentions',
+      nothing => 'Nothing',
+    };
+  }
+}
+
+class RadioGroupFormFieldPage extends StatefulWidget {
+  const RadioGroupFormFieldPage({super.key});
+
+  @override
+  State<RadioGroupFormFieldPage> createState() =>
+      _RadioGroupFormFieldPageState();
+}
+
+class _RadioGroupFormFieldPageState extends State<RadioGroupFormFieldPage> {
+  bool enabled = true;
+  var autovalidateMode = ShadAutovalidateMode.alwaysAfterFirstValidation;
+  NotifyAbout? initialValue;
+  Map<Object, dynamic> formValue = {};
+  final formKey = GlobalKey<ShadFormState>();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return ShadForm(
+      key: formKey,
+      enabled: enabled,
+      autovalidateMode: autovalidateMode,
+      initialValue: {'notify': initialValue},
+      child: BaseScaffold(
+        appBarTitle: 'RadioGroupFormField',
+        editable: [
+          MyBoolProperty(
+            label: 'Enabled',
+            value: enabled,
+            onChanged: (value) => setState(() => enabled = value),
+          ),
+          MyEnumProperty(
+            label: 'autovalidateMode',
+            value: autovalidateMode,
+            values: ShadAutovalidateMode.values,
+            onChanged: (value) {
+              if (value != null) {
+                setState(() => autovalidateMode = value);
+              }
+            },
+          ),
+          MyEnumProperty<NotifyAbout>(
+            label: 'Form Initial Value',
+            value: NotifyAbout.nothing,
+            values: NotifyAbout.values,
+            onChanged: (value) {
+              formKey.currentState!.setFieldValue('notify', value);
+            },
+          ),
+        ],
+        children: [
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 350),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                ShadRadioGroupFormField(
+                  id: 'notify',
+                  enabled: enabled,
+                  initialValue: initialValue,
+                  toValueTransformer: (value) => value?.name,
+                  items: NotifyAbout.values.map(
+                    (e) => ShadRadio(
+                      value: e,
+                      label: Text(e.message),
+                    ),
+                  ),
+                  label: const Text('Notify me about'),
+                  validator: (v) {
+                    if (v == null) {
+                      return 'You need to select a notification type.';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 16),
+                ShadButton(
+                  child: const Text('Submit'),
+                  onPressed: () {
+                    print('submitted');
+                    if (formKey.currentState!.saveAndValidate()) {
+                      setState(() {
+                        formValue = formKey.currentState!.value;
+                      });
+                    } else {
+                      print('validation failed');
+                    }
+                  },
+                ),
+                if (formValue.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 24, left: 12),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text('FormValue', style: theme.textTheme.p),
+                        const SizedBox(height: 4),
+                        SelectableText(
+                          const JsonEncoder.withIndent(
+                            '    ',
+                          ).convert(formValue),
+                          style: theme.textTheme.small,
+                        ),
+                      ],
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+```

--- a/skills/shadcn-ui-flutter/components/resizable.md
+++ b/skills/shadcn-ui-flutter/components/resizable.md
@@ -1,0 +1,284 @@
+# Resizable
+
+Resizable panel groups and layouts.
+
+
+
+```dart
+class BasicResizable extends StatelessWidget {
+  const BasicResizable({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxHeight: 200),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          borderRadius: theme.radius,
+          border: Border.all(
+            color: theme.colorScheme.border,
+          ),
+        ),
+        child: ClipRRect(
+          borderRadius: theme.radius,
+          child: ShadResizablePanelGroup(
+            children: [
+              ShadResizablePanel(
+                id: 0,
+                defaultSize: .5,
+                minSize: .2,
+                maxSize: .8,
+                child: Center(
+                  child: Text('One', style: theme.textTheme.large),
+                ),
+              ),
+              ShadResizablePanel(
+                id: 1,
+                defaultSize: .5,
+                child: ShadResizablePanelGroup(
+                  axis: Axis.vertical,
+                  children: [
+                    ShadResizablePanel(
+                      id: 0,
+                      defaultSize: .3,
+                      child: Center(
+                          child: Text('Two', style: theme.textTheme.large)),
+                    ),
+                    ShadResizablePanel(
+                      id: 1,
+                      defaultSize: .7,
+                      child: Align(
+                          child: Text('Three', style: theme.textTheme.large)),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+```
+
+
+
+Try resizing a panel, then double-click on the handle to reset to the default size.
+
+
+## Vertical
+
+Use the `axis` property to change the direction of the resizable panels.
+
+
+
+```dart
+class VerticalResizable extends StatelessWidget {
+  const VerticalResizable({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxHeight: 200),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          borderRadius: theme.radius,
+          border: Border.all(
+            color: theme.colorScheme.border,
+          ),
+        ),
+        child: ClipRRect(
+          borderRadius: theme.radius,
+          child: ShadResizablePanelGroup(
+            axis: Axis.vertical,
+            children: [
+              ShadResizablePanel(
+                id: 0,
+                defaultSize: 0.3,
+                minSize: 0.1,
+                child: Center(
+                  child: Text('Header', style: theme.textTheme.large),
+                ),
+              ),
+              ShadResizablePanel(
+                id: 1,
+                defaultSize: 0.7,
+                minSize: 0.1,
+                child: Center(
+                  child: Text('Footer', style: theme.textTheme.large),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+```
+
+
+
+## Handle
+
+You can show the handle by using the `showHandle` property.
+
+You can customize it using the `handleIcon` or `handleIconSrc` properties.
+
+
+
+```dart
+class HandleResizable extends StatelessWidget {
+  const HandleResizable({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxHeight: 200),
+      child: DecoratedBox(
+          decoration: BoxDecoration(
+            borderRadius: theme.radius,
+            border: Border.all(
+              color: theme.colorScheme.border,
+            ),
+          ),
+          child: ClipRRect(
+          borderRadius: theme.radius,
+          child: ShadResizablePanelGroup(
+            showHandle: true,
+            children: [
+              ShadResizablePanel(
+                id: 0,
+                defaultSize: .5,
+                minSize: .2,
+                child: Center(
+                  child: Text('Sidebar', style: theme.textTheme.large),
+                ),
+              ),
+              ShadResizablePanel(
+                id: 1,
+                defaultSize: .5,
+                minSize: .2,
+                child: Center(
+                  child: Text('Content', style: theme.textTheme.large),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+```
+
+## Example
+```dart
+import 'package:example/common/base_scaffold.dart';
+import 'package:example/common/properties/bool_property.dart';
+import 'package:flutter/material.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class ResizablePage extends StatefulWidget {
+  const ResizablePage({super.key});
+
+  @override
+  State<ResizablePage> createState() => _ResizablePageState();
+}
+
+class _ResizablePageState extends State<ResizablePage> {
+  var visible = true;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return BaseScaffold(
+      appBarTitle: 'Resizable',
+      editable: [
+        MyBoolProperty(
+          value: visible,
+          onChanged: (v) => setState(() => visible = v),
+          label: 'One Visible',
+        ),
+      ],
+      children: [
+        SizedBox(
+          width: 300,
+          height: 200,
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              borderRadius: theme.radius,
+              border: Border.all(
+                color: theme.colorScheme.border,
+              ),
+            ),
+            child: ClipRRect(
+              borderRadius: theme.radius,
+              child: ShadResizablePanelGroup(
+                mainAxisSize: MainAxisSize.min,
+                showHandle: true,
+                children: [
+                  if (visible)
+                    ShadResizablePanel(
+                      id: 0,
+                      defaultSize: .5,
+                      minSize: 0.1,
+                      maxSize: 0.8,
+                      child: Container(
+                        color: Colors.red,
+                        alignment: Alignment.center,
+                        child: Text(
+                          'One',
+                          style: theme.textTheme.large,
+                        ),
+                      ),
+                    ),
+                  ShadResizablePanel(
+                    defaultSize: 0.5,
+                    id: 1,
+                    child: ShadResizablePanelGroup(
+                      axis: Axis.vertical,
+                      showHandle: true,
+                      children: [
+                        ShadResizablePanel(
+                          id: 0,
+                          defaultSize: 0.4,
+                          child: Container(
+                            color: Colors.blue,
+                            alignment: Alignment.center,
+                            child: Text(
+                              'Two',
+                              style: theme.textTheme.large,
+                            ),
+                          ),
+                        ),
+                        ShadResizablePanel(
+                          id: 1,
+                          defaultSize: 0.6,
+                          child: Container(
+                            color: Colors.green,
+                            alignment: Alignment.center,
+                            child: Text(
+                              'Three',
+                              style: theme.textTheme.large,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+```

--- a/skills/shadcn-ui-flutter/components/select.md
+++ b/skills/shadcn-ui-flutter/components/select.md
@@ -1,0 +1,735 @@
+# Select
+
+Displays a list of options for the user to pick from—triggered by a button.
+
+
+
+```dart
+final fruits = {
+  'apple': 'Apple',
+  'banana': 'Banana',
+  'blueberry': 'Blueberry',
+  'grapes': 'Grapes',
+  'pineapple': 'Pineapple',
+};
+
+class SelectExample extends StatelessWidget {
+  const SelectExample({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return ConstrainedBox(
+      constraints: const BoxConstraints(minWidth: 180),
+      child: ShadSelect<String>(
+        placeholder: const Text('Select a fruit'),
+        options: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+            child: Text(
+              'Fruits',
+              style: theme.textTheme.muted.copyWith(
+                fontWeight: FontWeight.w600,
+                color: theme.colorScheme.popoverForeground,
+              ),
+              textAlign: TextAlign.start,
+            ),
+          ),
+          ...fruits.entries
+              .map((e) => ShadOption(value: e.key, child: Text(e.value))),
+        ],
+        selectedOptionBuilder: (context, value) => Text(fruits[value]!),
+        onChanged: print,
+      ),
+    );
+  }
+}
+```
+
+
+
+## Scrollable
+
+
+
+```dart
+final timezones = {
+  'North America': {
+    'est': 'Eastern Standard Time (EST)',
+    'cst': 'Central Standard Time (CST)',
+    'mst': 'Mountain Standard Time (MST)',
+    'pst': 'Pacific Standard Time (PST)',
+    'akst': 'Alaska Standard Time (AKST)',
+    'hst': 'Hawaii Standard Time (HST)',
+  },
+  'Europe & Africa': {
+    'gmt': 'Greenwich Mean Time (GMT)',
+    'cet': 'Central European Time (CET)',
+    'eet': 'Eastern European Time (EET)',
+    'west': 'Western European Summer Time (WEST)',
+    'cat': 'Central Africa Time (CAT)',
+    'eat': 'Eastern Africa Time (EAT)',
+  },
+  'Asia': {
+    'msk': 'Moscow Time (MSK)',
+    'ist': 'India Standard Time (IST)',
+    'cst_china': 'China Standard Time (CST)',
+    'jst': 'Japan Standard Time (JST)',
+    'kst': 'Korea Standard Time (KST)',
+    'ist_indonasia': 'Indonesia Standard Time (IST)',
+  },
+  'Australia & Pacific': {
+    'awst': 'Australian Western Standard Time (AWST)',
+    'acst': 'Australian Central Standard Time (ACST)',
+    'aest': 'Australian Eastern Standard Time (AEST)',
+    'nzst': 'New Zealand Standard Time (NZST)',
+    'fjt': 'Fiji Time (FJT)',
+  },
+  'South America': {
+    'art': 'Argentina Time (ART)',
+    'bot': 'Bolivia Time (BOT)',
+    'brt': 'Brasilia Time (BRT)',
+    'clt': 'Chile Standard Time (CLT)',
+  },
+};
+
+List<Widget> getTimezonesWidgets(ShadThemeData theme) {
+  final widgets = <Widget>[];
+  for (final zone in timezones.entries) {
+    widgets.add(
+      Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+        child: Text(
+          zone.key,
+          style: theme.textTheme.muted.copyWith(
+            fontWeight: FontWeight.w600,
+            color: theme.colorScheme.popoverForeground,
+          ),
+          textAlign: TextAlign.start,
+        ),
+      ),
+    );
+    widgets.addAll(zone.value.entries
+        .map((e) => ShadOption(value: e.key, child: Text(e.value))));
+  }
+  return widgets;
+}
+
+class SelectExample extends StatelessWidget {
+  const SelectExample({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return ConstrainedBox(
+      constraints: const BoxConstraints(minWidth: 280),
+      child: ShadSelect<String>(
+        placeholder: const Text('Select a timezone'),
+        options: getTimezonesWidgets(theme),
+        selectedOptionBuilder: (context, value) {
+          final timezone = timezones.entries
+              .firstWhere((element) => element.value.containsKey(value))
+              .value[value];
+          return Text(timezone!);
+        },
+      ),
+    );
+  }
+}
+```
+
+
+
+## Form
+
+
+
+```dart
+final verifiedEmails = [
+  'm@example.com',
+  'm@google.com',
+  'm@support.com',
+];
+
+class SelectFormField extends StatelessWidget {
+  const SelectFormField({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ShadSelectFormField<String>(
+      id: 'email',
+      minWidth: 350,
+      initialValue: null,
+      options: verifiedEmails
+          .map((email) => ShadOption(value: email, child: Text(email)))
+          .toList(),
+      selectedOptionBuilder: (context, value) => value == 'none'
+          ? const Text('Select a verified email to display')
+          : Text(value),
+      placeholder: const Text('Select a verified email to display'),
+      validator: (v) {
+        if (v == null) {
+          return 'Please select an email to display';
+        }
+        return null;
+      },
+    );
+  }
+}
+```
+
+
+
+## With Search
+
+
+
+```dart
+const frameworks = {
+'nextjs': 'Next.js',
+'svelte': 'SvelteKit',
+'nuxtjs': 'Nuxt.js',
+'remix': 'Remix',
+'astro': 'Astro',
+};
+
+class SelectWithSearch extends StatefulWidget {
+  const SelectWithSearch({super.key});
+
+  @override
+  State<SelectWithSearch> createState() => _SelectWithSearchState();
+}
+
+class _SelectWithSearchState extends State<SelectWithSearch> {
+  var searchValue = '';
+
+  Map<String, String> get filteredFrameworks => {
+  for (final framework in frameworks.entries)
+  if (framework.value.toLowerCase().contains(searchValue.toLowerCase()))
+  framework.key: framework.value
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    return ShadSelect<String>.withSearch(
+      minWidth: 180,
+      maxWidth: 300,
+      placeholder: const Text('Select framework...'),
+      onSearchChanged: (value) => setState(() => searchValue = value),
+      searchPlaceholder: const Text('Search framework'),
+      options: [
+        if (filteredFrameworks.isEmpty)
+          const Padding(
+            padding: EdgeInsets.symmetric(vertical: 24),
+            child: Text('No framework found'),
+          ),
+        ...frameworks.entries.map(
+          (framework) {
+            // this offstage is used to avoid the focus loss when the search results appear again
+            // because it keeps the widget in the tree.
+            return Offstage(
+              offstage: !filteredFrameworks.containsKey(framework.key),
+              child: ShadOption(
+                value: framework.key,
+                child: Text(framework.value),
+              ),
+            );
+          },
+        )
+      ],
+      selectedOptionBuilder: (context, value) => Text(frameworks[value]!),
+    );
+  }
+}
+```
+
+
+
+If you want to be able to deselect an option, you can use the `allowDeselection` property.
+
+
+## Multiple
+
+This example shows how to select multiple options.
+
+In addition, the `allowDeselection` property is set to `true` to allow the user to deselect an option and the `closeOnSelect` property is set to `false` to keep the popover open after selecting an option.
+If you tap outside the popover, it will close.
+
+
+
+```dart
+final fruits = {
+  'apple': 'Apple',
+  'banana': 'Banana',
+  'blueberry': 'Blueberry',
+  'grapes': 'Grapes',
+  'pineapple': 'Pineapple',
+};
+
+class SelectMultiple extends StatelessWidget {
+  const SelectMultiple({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return ShadSelect<String>.multiple(
+      minWidth: 340,
+      onChanged: print,
+      allowDeselection: true,
+      closeOnSelect: false,
+      placeholder: const Text('Select multiple fruits'),
+      options: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+          child: Text(
+            'Fruits',
+            style: theme.textTheme.large,
+            textAlign: TextAlign.start,
+          ),
+        ),
+        ...fruits.entries.map(
+          (e) => ShadOption(
+            value: e.key,
+            child: Text(e.value),
+          ),
+        ),
+      ],
+      selectedOptionsBuilder: (context, values) =>
+          Text(values.map((v) => v.capitalize()).join(', ')),
+    );
+  }
+}
+```
+
+## Example
+```dart
+// ignore_for_file: avoid_print
+
+import 'package:awesome_flutter_extensions/awesome_flutter_extensions.dart';
+import 'package:example/common/base_scaffold.dart';
+import 'package:example/common/properties/bool_property.dart';
+import 'package:flutter/material.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+const fruits = {
+  'apple': 'Apple',
+  'banana': 'Banana',
+  'blueberry': 'Blueberry',
+  'grapes': 'Grapes',
+  'pineapple': 'Pineapple',
+};
+
+const timezones = {
+  'North America': {
+    'est': 'Eastern Standard Time (EST)',
+    'cst': 'Central Standard Time (CST)',
+    'mst': 'Mountain Standard Time (MST)',
+    'pst': 'Pacific Standard Time (PST)',
+    'akst': 'Alaska Standard Time (AKST)',
+    'hst': 'Hawaii Standard Time (HST)',
+  },
+  'Europe & Africa': {
+    'gmt': 'Greenwich Mean Time (GMT)',
+    'cet': 'Central European Time (CET)',
+    'eet': 'Eastern European Time (EET)',
+    'west': 'Western European Summer Time (WEST)',
+    'cat': 'Central Africa Time (CAT)',
+    'eat': 'Eastern Africa Time (EAT)',
+  },
+  'Asia': {
+    'msk': 'Moscow Time (MSK)',
+    'ist': 'India Standard Time (IST)',
+    'cst_china': 'China Standard Time (CST)',
+    'jst': 'Japan Standard Time (JST)',
+    'kst': 'Korea Standard Time (KST)',
+    'ist_indonasia': 'Indonesia Standard Time (IST)',
+  },
+  'Australia & Pacific': {
+    'awst': 'Australian Western Standard Time (AWST)',
+    'acst': 'Australian Central Standard Time (ACST)',
+    'aest': 'Australian Eastern Standard Time (AEST)',
+    'nzst': 'New Zealand Standard Time (NZST)',
+    'fjt': 'Fiji Time (FJT)',
+  },
+  'South America': {
+    'art': 'Argentina Time (ART)',
+    'bot': 'Bolivia Time (BOT)',
+    'brt': 'Brasilia Time (BRT)',
+    'clt': 'Chile Standard Time (CLT)',
+  },
+};
+
+const frameworks = {
+  'nextjs': 'Next.js',
+  'svelte': 'SvelteKit',
+  'nuxtjs': 'Nuxt.js',
+  'remix': 'Remix',
+  'astro': 'Astro',
+};
+
+class SelectPage extends StatefulWidget {
+  const SelectPage({super.key});
+
+  @override
+  State<SelectPage> createState() => _SelectPageState();
+}
+
+class _SelectPageState extends State<SelectPage> {
+  bool enabled = true;
+  final focusNodes = [FocusNode(), FocusNode(), FocusNode(), FocusNode()];
+  var searchValue = '';
+  bool allowDeselection = false;
+  bool closeOnSelect = true;
+  bool ensureSelectedVisible = true;
+
+  Map<String, String> get filteredFrameworks => {
+    for (final framework in frameworks.entries)
+      if (framework.value.toLowerCase().contains(searchValue.toLowerCase()))
+        framework.key: framework.value,
+  };
+
+  @override
+  void dispose() {
+    for (final node in focusNodes) {
+      node.dispose();
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return BaseScaffold(
+      appBarTitle: 'Select',
+      editable: [
+        MyBoolProperty(
+          label: 'Enabled',
+          value: enabled,
+          onChanged: (value) => setState(() => enabled = value),
+        ),
+        MyBoolProperty(
+          label: 'Fruits Focused',
+          value: focusNodes[0].hasFocus,
+          onChanged: (value) => setState(
+            () =>
+                value ? focusNodes[0].requestFocus() : focusNodes[0].unfocus(),
+          ),
+        ),
+        MyBoolProperty(
+          label: 'Timezone Focused',
+          value: focusNodes[1].hasFocus,
+          onChanged: (value) => setState(
+            () =>
+                value ? focusNodes[1].requestFocus() : focusNodes[1].unfocus(),
+          ),
+        ),
+        MyBoolProperty(
+          label: 'Framework Focused',
+          value: focusNodes[2].hasFocus,
+          onChanged: (value) => setState(
+            () =>
+                value ? focusNodes[2].requestFocus() : focusNodes[2].unfocus(),
+          ),
+        ),
+        MyBoolProperty(
+          label: 'Allow deselection',
+          value: allowDeselection,
+          onChanged: (value) => setState(() => allowDeselection = value),
+        ),
+        MyBoolProperty(
+          label: 'Close on select',
+          value: closeOnSelect,
+          onChanged: (value) => setState(() => closeOnSelect = value),
+        ),
+        MyBoolProperty(
+          label: 'Ensure selected visible',
+          value: ensureSelectedVisible,
+          onChanged: (value) => setState(() => ensureSelectedVisible = value),
+        ),
+      ],
+      children: [
+        ShadSelect<String>(
+          minWidth: 180,
+          onChanged: print,
+          closeOnSelect: closeOnSelect,
+          enabled: enabled,
+          focusNode: focusNodes[0],
+          placeholder: const Text('Select a fruit'),
+          allowDeselection: allowDeselection,
+          ensureSelectedVisible: ensureSelectedVisible,
+          options: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+              child: Text(
+                'Fruits',
+                style: theme.textTheme.large,
+                textAlign: TextAlign.start,
+              ),
+            ),
+            ...fruits.entries.map(
+              (e) => ShadOption(
+                value: e.key,
+                child: Text(e.value),
+              ),
+            ),
+          ],
+          selectedOptionBuilder: (context, value) => Text(value.capitalize()),
+        ),
+        ShadSelect<String>(
+          minWidth: 280,
+          focusNode: focusNodes[1],
+          onChanged: print,
+          enabled: enabled,
+          closeOnSelect: closeOnSelect,
+          placeholder: const Text('Select a timezone'),
+          ensureSelectedVisible: ensureSelectedVisible,
+          options: timezones.entries.map(
+            (zone) => Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 6,
+                  ),
+                  child: Text(
+                    zone.key,
+                    style: theme.textTheme.muted.copyWith(
+                      fontWeight: FontWeight.w600,
+                      color: theme.colorScheme.popoverForeground,
+                    ),
+                    textAlign: TextAlign.start,
+                  ),
+                ),
+                ...zone.value.entries.map(
+                  (e) => ShadOption(
+                    value: e.key,
+                    child: Text(e.value),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          allowDeselection: allowDeselection,
+          selectedOptionBuilder: (context, value) {
+            final timezone = timezones.entries
+                .firstWhere((element) => element.value.containsKey(value))
+                .value[value];
+            return Text(timezone!);
+          },
+        ),
+        ShadSelect<String>.withSearch(
+          enabled: enabled,
+          focusNode: focusNodes[2],
+          minWidth: 180,
+          maxWidth: 300,
+          placeholder: const Text('Select framework...'),
+          onSearchChanged: (value) => setState(() => searchValue = value),
+          closeOnSelect: closeOnSelect,
+          searchPlaceholder: const Text('Search framework'),
+          ensureSelectedVisible: ensureSelectedVisible,
+          options: [
+            if (filteredFrameworks.isEmpty)
+              const Padding(
+                padding: EdgeInsets.symmetric(vertical: 24),
+                child: Text('No framework found'),
+              ),
+            ...frameworks.entries.map(
+              (framework) {
+                // this offstage is used to avoid the focus loss when the search results appear again
+                // because it keeps the widget in the tree.
+                return Offstage(
+                  offstage: !filteredFrameworks.containsKey(framework.key),
+                  child: ShadOption(
+                    value: framework.key,
+                    child: Text(framework.value),
+                  ),
+                );
+              },
+            ),
+          ],
+          selectedOptionBuilder: (context, value) => Text(frameworks[value]!),
+          onChanged: print,
+          allowDeselection: allowDeselection,
+        ),
+        ShadSelect<String>.multiple(
+          minWidth: 340,
+          onChanged: print,
+          enabled: enabled,
+          focusNode: focusNodes[3],
+          allowDeselection: allowDeselection,
+          placeholder: const Text('Select multiple fruits'),
+          closeOnSelect: closeOnSelect,
+          ensureSelectedVisible: ensureSelectedVisible,
+          options: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+              child: Text(
+                'Fruits',
+                style: theme.textTheme.large,
+                textAlign: TextAlign.start,
+              ),
+            ),
+            ...fruits.entries.map(
+              (e) => ShadOption(
+                value: e.key,
+                child: Text(e.value),
+              ),
+            ),
+          ],
+          selectedOptionsBuilder: (context, values) =>
+              Text(values.map((v) => v.capitalize()).join(', ')),
+        ),
+      ],
+    );
+  }
+}
+
+```
+
+## Form Example
+```dart
+// ignore_for_file: avoid_print
+
+import 'dart:convert';
+
+import 'package:example/common/base_scaffold.dart';
+import 'package:example/common/properties/bool_property.dart';
+import 'package:example/common/properties/enum_property.dart';
+import 'package:flutter/material.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class SelectFormFieldPage extends StatefulWidget {
+  const SelectFormFieldPage({super.key});
+
+  @override
+  State<SelectFormFieldPage> createState() => _SelectFormFieldPageState();
+}
+
+class _SelectFormFieldPageState extends State<SelectFormFieldPage> {
+  bool enabled = true;
+  var autovalidateMode = ShadAutovalidateMode.alwaysAfterFirstValidation;
+  final verifiedEmails = [
+    'm@example.com',
+    'm@google.com',
+    'm@support.com',
+  ];
+  String? initialValue;
+  Map<Object, dynamic> formValue = {};
+  final formKey = GlobalKey<ShadFormState>();
+  bool allowDeselection = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return ShadForm(
+      key: formKey,
+      enabled: enabled,
+      autovalidateMode: autovalidateMode,
+      initialValue: {'email': initialValue},
+      child: BaseScaffold(
+        appBarTitle: 'SelectFormField',
+        editable: [
+          MyBoolProperty(
+            label: 'Enabled',
+            value: enabled,
+            onChanged: (value) => setState(() => enabled = value),
+          ),
+          MyEnumProperty(
+            label: 'autovalidateMode',
+            value: autovalidateMode,
+            values: ShadAutovalidateMode.values,
+            onChanged: (value) {
+              if (value != null) {
+                setState(() => autovalidateMode = value);
+              }
+            },
+          ),
+          ShadSelect(
+            options: ['none', ...verifiedEmails].map(
+              (e) => ShadOption(value: e, child: Text(e.toString())),
+            ),
+            initialValue: initialValue,
+            placeholder: const Text('Form Initial Value'),
+            onChanged: (v) {
+              formKey.currentState!.setFieldValue('email', v);
+            },
+            selectedOptionBuilder: (context, value) => Text(
+              value.toString(),
+            ),
+          ),
+          MyBoolProperty(
+            label: 'Allow deselection',
+            value: allowDeselection,
+            onChanged: (value) => setState(() => allowDeselection = value),
+          ),
+        ],
+        children: [
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 350),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                ShadSelectFormField(
+                  id: 'email',
+                  allowDeselection: allowDeselection,
+                  minWidth: 350,
+                  initialValue: initialValue,
+                  onChanged: print,
+                  options: verifiedEmails
+                      .map(
+                        (email) => ShadOption(value: email, child: Text(email)),
+                      )
+                      .toList(),
+                  selectedOptionBuilder: (context, value) => value == 'none'
+                      ? const Text('Select a verified email to display')
+                      : Text(value),
+                  placeholder: const Text('Select a verified email to display'),
+                  validator: (v) {
+                    if (v == null) {
+                      return 'Please select an email to display';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 16),
+                ShadButton(
+                  child: const Text('Submit'),
+                  onPressed: () {
+                    print('submitted');
+                    if (formKey.currentState!.saveAndValidate()) {
+                      setState(() {
+                        formValue = formKey.currentState!.value;
+                      });
+                    } else {
+                      print('validation failed');
+                    }
+                  },
+                ),
+                if (formValue.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 24, left: 12),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text('FormValue', style: theme.textTheme.p),
+                        const SizedBox(height: 4),
+                        SelectableText(
+                          const JsonEncoder.withIndent(
+                            '    ',
+                          ).convert(formValue),
+                          style: theme.textTheme.small,
+                        ),
+                      ],
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+```

--- a/skills/shadcn-ui-flutter/components/separator.md
+++ b/skills/shadcn-ui-flutter/components/separator.md
@@ -1,0 +1,110 @@
+# Separator
+
+Visually or semantically separates content.
+
+
+
+```dart
+const ShadSeparator.horizontal(
+  thickness: 4,
+  margin: EdgeInsets.symmetric(horizontal: 20),
+  radius: BorderRadius.all(Radius.circular(4)),
+)
+```
+
+
+
+## Destructive
+
+
+
+```dart
+const ShadSeparator.vertical(
+  thickness: 4,
+  margin: EdgeInsets.symmetric(vertical: 20),
+  radius: BorderRadius.all(Radius.circular(4)),
+)
+```
+
+## Example
+```dart
+import 'package:example/common/base_scaffold.dart';
+import 'package:example/common/properties/string_property.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class SeparatorPage extends StatefulWidget {
+  const SeparatorPage({super.key});
+
+  @override
+  State<SeparatorPage> createState() => _SeparatorPageState();
+}
+
+class _SeparatorPageState extends State<SeparatorPage> {
+  int margin = 4;
+  int thickness = 1;
+  int radius = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return BaseScaffold(
+      appBarTitle: 'Separator',
+      editable: [
+        MyStringProperty(
+          label: 'margin',
+          initialValue: '$margin',
+          inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+          onChanged: (value) {
+            var maybe = int.tryParse(value);
+            if (maybe != null) setState(() => margin = maybe);
+          },
+        ),
+        MyStringProperty(
+          label: 'thickness',
+          initialValue: '$thickness',
+          inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+          onChanged: (value) {
+            var maybe = int.tryParse(value);
+            if (maybe != null) setState(() => thickness = maybe);
+          },
+        ),
+        MyStringProperty(
+          label: 'radius',
+          initialValue: '$radius',
+          inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+          onChanged: (value) {
+            var maybe = int.tryParse(value);
+            if (maybe != null) setState(() => radius = maybe);
+          },
+        ),
+      ],
+      children: [
+        Text('Horizontal', style: theme.textTheme.h4),
+        ShadSeparator.horizontal(
+          thickness: thickness.toDouble(),
+          margin: EdgeInsets.all(margin.toDouble()),
+          radius: BorderRadius.all(Radius.circular(radius.toDouble())),
+        ),
+        IntrinsicHeight(
+          child: Row(
+            mainAxisSize: MainAxisSize.max,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text('Vertical', style: theme.textTheme.h4),
+              ShadSeparator.vertical(
+                thickness: thickness.toDouble(),
+                margin: EdgeInsets.all(margin.toDouble()),
+                radius: BorderRadius.all(Radius.circular(radius.toDouble())),
+              ),
+              Text('divider', style: theme.textTheme.h4),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+```

--- a/skills/shadcn-ui-flutter/components/sheet.md
+++ b/skills/shadcn-ui-flutter/components/sheet.md
@@ -1,0 +1,273 @@
+# Sheet
+
+Extends the Dialog component to display content that complements the main content of the screen.
+
+
+
+```dart
+ShadButton.outline(
+  child: const Text('Open'),
+  onPressed: () => showShadSheet(
+    side: ShadSheetSide.right,
+    context: context,
+    builder: (context) => const EditProfileSheet(),
+  ),
+),
+
+final profile = [
+  (title: 'Name', value: 'Alexandru'),
+  (title: 'Username', value: 'nank1ro'),
+];
+
+class EditProfileSheet extends StatelessWidget {
+  const EditProfileSheet({super.key, required this.side});
+
+  final ShadSheetSide side;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return ShadSheet(
+      constraints: side == ShadSheetSide.left || side == ShadSheetSide.right
+          ? const BoxConstraints(maxWidth: 512)
+          : null,
+      title: const Text('Edit Profile'),
+      description: const Text(
+          "Make changes to your profile here. Click save when you're done"),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: 20),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          spacing: 16,
+          children: profile
+              .map(
+                (p) => Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        p.title,
+                        textAlign: TextAlign.end,
+                        style: theme.textTheme.small,
+                      ),
+                    ),
+                    const SizedBox(width: 16),
+                    Expanded(
+                      flex: 5,
+                      child: ShadInput(initialValue: p.value),
+                    ),
+                  ],
+                ),
+              )
+              .toList(),
+        ),
+      ),
+      actions: const [
+        ShadButton(child: Text('Save changes')),
+      ],
+    );
+  }
+}
+```
+
+
+
+## Side
+
+Use the `side` property to `showShadSheet` to indicate the edge of the screen where the component will appear. The values can be `top`, `right`, `bottom` or `left`.
+
+
+
+```dart
+Row(
+  mainAxisSize: MainAxisSize.min,
+  spacing: 16,
+  children: [
+    Column(
+      spacing: 16,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        ShadButton.outline(
+          width: 100,
+          child: const Text('Top'),
+          onPressed: () => showShadSheet(
+            side: ShadSheetSide.top,
+            context: context,
+            builder: (context) =>
+                const EditProfileSheet(side: ShadSheetSide.top),
+          ),
+        ),
+        ShadButton.outline(
+          width: 100,
+          child: const Text('Bottom'),
+          onPressed: () => showShadSheet(
+            side: ShadSheetSide.bottom,
+            context: context,
+            builder: (context) => const EditProfileSheet(
+                side: ShadSheetSide.bottom),
+          ),
+        ),
+      ],
+    ),
+    Column(
+      spacing: 16,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        ShadButton.outline(
+          width: 100,
+          child: const Text('Right'),
+          onPressed: () => showShadSheet(
+            side: ShadSheetSide.right,
+            context: context,
+            builder: (context) => const EditProfileSheet(
+                side: ShadSheetSide.right),
+          ),
+        ),
+        ShadButton.outline(
+          width: 100,
+          child: const Text('Left'),
+          onPressed: () => showShadSheet(
+            side: ShadSheetSide.left,
+            context: context,
+            builder: (context) => const EditProfileSheet(
+                side: ShadSheetSide.left),
+          ),
+        ),
+      ],
+    ),
+  ],
+),
+
+// See EditProfileSheet code in the previous code example
+```
+
+## Example
+```dart
+import 'package:example/common/base_scaffold.dart';
+import 'package:example/common/extensions.dart';
+import 'package:example/common/properties/bool_property.dart';
+import 'package:example/common/properties/enum_property.dart';
+import 'package:flutter/material.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+final profile = [
+  (title: 'Name', value: 'Alexandru'),
+  (title: 'Username', value: 'nank1ro'),
+];
+
+class SheetPage extends StatefulWidget {
+  const SheetPage({super.key});
+
+  @override
+  State<SheetPage> createState() => _SheetPageState();
+}
+
+class _SheetPageState extends State<SheetPage> {
+  var side = ShadSheetSide.bottom;
+  var draggable = false;
+  var titlePinned = false;
+  var descriptionPinned = false;
+  var actionsPinned = true;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return BaseScaffold(
+      appBarTitle: 'Sheet',
+      editable: [
+        MyEnumProperty(
+          label: 'Side',
+          value: side,
+          values: ShadSheetSide.values,
+          onChanged: (value) {
+            if (value != null) {
+              setState(() {
+                side = value;
+              });
+            }
+          },
+        ),
+        MyBoolProperty(
+          label: 'Draggable',
+          value: draggable,
+          onChanged: (value) => setState(() => draggable = value),
+        ),
+        MyBoolProperty(
+          label: 'titlePinned',
+          value: titlePinned,
+          onChanged: (v) => setState(() => titlePinned = v),
+        ),
+        MyBoolProperty(
+          label: 'descriptionPinned',
+          value: descriptionPinned,
+          onChanged: (v) => setState(() => descriptionPinned = v),
+        ),
+        MyBoolProperty(
+          label: 'actionsPinned',
+          value: actionsPinned,
+          onChanged: (v) => setState(() => actionsPinned = v),
+        ),
+      ],
+      children: [
+        ShadButton.outline(
+          child: const Text('Open'),
+          onPressed: () {
+            showShadSheet(
+              context: context,
+              side: side,
+              builder: (context) {
+                return ShadSheet(
+                  draggable: draggable,
+                  constraints:
+                      side == ShadSheetSide.left || side == ShadSheetSide.right
+                      ? const BoxConstraints(maxWidth: 512)
+                      : null,
+                  title: const Text('Edit Profile'),
+                  description: const Text(
+                    "Make changes to your profile here. Click save when you're done",
+                  ),
+                  actions: const [ShadButton(child: Text('Save changes'))],
+                  titlePinned: titlePinned,
+                  descriptionPinned: descriptionPinned,
+                  actionsPinned: actionsPinned,
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 20),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      spacing: 16,
+                      children:
+                          (profile.map(
+                                    (p) => Row(
+                                      children: [
+                                        Expanded(
+                                          child: Text(
+                                            p.title,
+                                            textAlign: TextAlign.end,
+                                            style: theme.textTheme.small,
+                                          ),
+                                        ),
+                                        const SizedBox(width: 16),
+                                        Expanded(
+                                          flex: 5,
+                                          child: ShadInput(
+                                            initialValue: p.value,
+                                          ),
+                                        ),
+                                      ],
+                                    ),
+                                  ) *
+                                  20)
+                              .toList(),
+                    ),
+                  ),
+                );
+              },
+            );
+          },
+        ),
+      ],
+    );
+  }
+}
+
+```

--- a/skills/shadcn-ui-flutter/components/slider.md
+++ b/skills/shadcn-ui-flutter/components/slider.md
@@ -1,0 +1,81 @@
+# Slider
+
+An input where the user selects a value from within a given range.
+
+
+
+```dart
+ShadSlider(
+  initialValue: 33,
+  max: 100,
+),
+```
+
+## Example
+```dart
+import 'package:example/common/base_scaffold.dart';
+import 'package:example/common/properties/bool_property.dart';
+import 'package:example/common/properties/enum_property.dart';
+import 'package:example/common/properties/string_property.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class SliderPage extends StatefulWidget {
+  const SliderPage({super.key});
+
+  @override
+  State<SliderPage> createState() => _SliderPageState();
+}
+
+class _SliderPageState extends State<SliderPage> {
+  var enabled = true;
+  double value = 33;
+  ShadSliderInteraction sliderInteraction = ShadSliderInteraction.tapAndSlide;
+  int? divisions;
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseScaffold(
+      appBarTitle: 'Slider',
+      editable: [
+        MyBoolProperty(
+          label: 'Enabled',
+          value: enabled,
+          onChanged: (value) => setState(() => enabled = value),
+        ),
+        MyEnumProperty(
+          label: 'Interaction',
+          value: sliderInteraction,
+          values: ShadSliderInteraction.values,
+          onChanged: (value) => setState(() => sliderInteraction = value!),
+        ),
+        MyStringProperty(
+          label: 'Divisions',
+          initialValue: divisions?.toString() ?? '',
+          onChanged: (v) {
+            setState(() {
+              final parsed = int.tryParse(v);
+              divisions = parsed;
+            });
+          },
+          inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+        ),
+      ],
+      children: [
+        ShadSlider(
+          initialValue: 33,
+          max: 100,
+          enabled: enabled,
+          onChanged: print,
+          allowedInteraction: sliderInteraction,
+          semanticFormatterCallback: (double value) =>
+              '${value.round()}% volume level',
+          divisions: divisions,
+        ),
+      ],
+    );
+  }
+}
+
+```

--- a/skills/shadcn-ui-flutter/components/sonner.md
+++ b/skills/shadcn-ui-flutter/components/sonner.md
@@ -1,0 +1,76 @@
+# Sonner
+
+An opinionated toast component.
+
+
+
+```dart
+ShadButton.outline(
+  child: const Text('Show Toast'),
+  onPressed: () {
+    final sonner = ShadSonner.of(context);
+    final id = Random().nextInt(1000);
+    final now = DateTime.now();
+    sonner.show(
+      ShadToast(
+        id: id,
+        title: const Text('Event has been created'),
+        description: Text(DateFormat.yMd().add_jms().format(now)),
+        action: ShadButton(
+          child: const Text('Undo'),
+          onPressed: () => sonner.hide(id),
+        ),
+      ),
+    );
+  },
+),
+```
+
+## Example
+```dart
+import 'dart:math';
+
+import 'package:example/common/base_scaffold.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class SonnerPage extends StatefulWidget {
+  const SonnerPage({super.key});
+
+  @override
+  State<SonnerPage> createState() => _SonnerPageState();
+}
+
+class _SonnerPageState extends State<SonnerPage>
+    with SingleTickerProviderStateMixin {
+  @override
+  Widget build(BuildContext context) {
+    return BaseScaffold(
+      appBarTitle: 'Sonner',
+      children: [
+        ShadButton.outline(
+          child: const Text('Show Toast'),
+          onPressed: () {
+            final sonner = ShadSonner.of(context);
+            final id = Random().nextInt(1000);
+            final now = DateTime.now();
+            sonner.show(
+              ShadToast(
+                id: id,
+                title: const Text('Event has been created'),
+                description: Text(DateFormat.yMd().add_jms().format(now)),
+                action: ShadButton(
+                  child: const Text('Undo'),
+                  onPressed: () => sonner.hide(id),
+                ),
+              ),
+            );
+          },
+        ),
+      ],
+    );
+  }
+}
+
+```

--- a/skills/shadcn-ui-flutter/components/switch.md
+++ b/skills/shadcn-ui-flutter/components/switch.md
@@ -1,0 +1,240 @@
+# Switch
+
+A control that allows the user to toggle between checked and not checked.
+
+
+
+```dart
+class SwitchExample extends StatefulWidget {
+  const SwitchExample({super.key});
+
+  @override
+  State<SwitchExample> createState() => _SwitchExampleState();
+}
+
+class _SwitchExampleState extends State<SwitchExample> {
+  bool value = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return ShadSwitch(
+      value: value,
+      onChanged: (v) => setState(() => value = v),
+      label: const Text('Airplane Mode'),
+    );
+  }
+}
+```
+
+
+
+## Form
+
+
+
+```dart
+ShadSwitchFormField(
+  id: 'terms',
+  initialValue: false,
+  inputLabel:
+      const Text('I accept the terms and conditions'),
+  onChanged: (v) {},
+  inputSublabel:
+      const Text('You agree to our Terms and Conditions'),
+  validator: (v) {
+    if (!v) {
+      return 'You must accept the terms and conditions';
+    }
+    return null;
+  },
+)
+```
+
+## Example
+```dart
+import 'package:example/common/base_scaffold.dart';
+import 'package:example/common/properties/bool_property.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class SwitchPage extends StatefulWidget {
+  const SwitchPage({super.key});
+
+  @override
+  State<SwitchPage> createState() => _SwitchPageState();
+}
+
+class _SwitchPageState extends State<SwitchPage> {
+  bool value = false;
+  bool enabled = true;
+  final focusNode = FocusNode();
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseScaffold(
+      appBarTitle: 'Switch',
+      editable: [
+        MyBoolProperty(
+          label: 'Enabled',
+          value: enabled,
+          onChanged: (value) => setState(() => enabled = value),
+        ),
+        MyBoolProperty(
+          label: 'Focused',
+          value: focusNode.hasFocus,
+          onChanged: enabled
+              ? (value) {
+                  setState(() {
+                    if (value) {
+                      focusNode.requestFocus();
+                    } else {
+                      focusNode.unfocus();
+                    }
+                  });
+                }
+              : null,
+        ),
+      ],
+      children: [
+        ShadSwitch(
+          value: value,
+          focusNode: focusNode,
+          enabled: enabled,
+          onChanged: (v) {
+            setState(() => value = v);
+          },
+          label: const Text('Airplane Mode'),
+        ),
+      ],
+    );
+  }
+}
+
+```
+
+## Form Example
+```dart
+// ignore_for_file: avoid_print
+
+import 'dart:convert';
+
+import 'package:example/common/base_scaffold.dart';
+import 'package:example/common/properties/bool_property.dart';
+import 'package:example/common/properties/enum_property.dart';
+import 'package:flutter/material.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class SwitchFormFieldPage extends StatefulWidget {
+  const SwitchFormFieldPage({super.key});
+
+  @override
+  State<SwitchFormFieldPage> createState() => _SwitchFormFieldPageState();
+}
+
+class _SwitchFormFieldPageState extends State<SwitchFormFieldPage> {
+  bool enabled = true;
+  var autovalidateMode = ShadAutovalidateMode.alwaysAfterFirstValidation;
+  bool initialValue = false;
+  Map<Object, dynamic> formValue = {};
+  final formKey = GlobalKey<ShadFormState>();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return ShadForm(
+      key: formKey,
+      enabled: enabled,
+      autovalidateMode: autovalidateMode,
+      initialValue: {'terms': initialValue},
+      child: BaseScaffold(
+        appBarTitle: 'SwitchFormField',
+        editable: [
+          MyBoolProperty(
+            label: 'Enabled',
+            value: enabled,
+            onChanged: (value) => setState(() => enabled = value),
+          ),
+          MyEnumProperty(
+            label: 'autovalidateMode',
+            value: autovalidateMode,
+            values: ShadAutovalidateMode.values,
+            onChanged: (value) {
+              if (value != null) {
+                setState(() => autovalidateMode = value);
+              }
+            },
+          ),
+          MyBoolProperty(
+            label: 'Form Initial Value',
+            value: initialValue,
+            onChanged: (value) {
+              formKey.currentState!.setFieldValue('terms', value);
+              setState(() {
+                initialValue = value;
+              });
+            },
+          ),
+        ],
+        children: [
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 350),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                ShadSwitchFormField(
+                  id: 'terms',
+                  initialValue: initialValue,
+                  inputLabel: const Text('I accept the terms and conditions'),
+                  onChanged: (v) {},
+                  inputSublabel: const Text(
+                    'You agree to our Terms and Conditions',
+                  ),
+                  validator: (v) {
+                    if (!v) {
+                      return 'You must accept the terms and conditions';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 16),
+                ShadButton(
+                  child: const Text('Submit'),
+                  onPressed: () {
+                    print('submitted');
+                    if (formKey.currentState!.saveAndValidate()) {
+                      setState(() {
+                        formValue = formKey.currentState!.value;
+                      });
+                    } else {
+                      print('validation failed');
+                    }
+                  },
+                ),
+                if (formValue.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 24, left: 12),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text('FormValue', style: theme.textTheme.p),
+                        const SizedBox(height: 4),
+                        SelectableText(
+                          const JsonEncoder.withIndent(
+                            '    ',
+                          ).convert(formValue),
+                          style: theme.textTheme.small,
+                        ),
+                      ],
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+```

--- a/skills/shadcn-ui-flutter/components/table.md
+++ b/skills/shadcn-ui-flutter/components/table.md
@@ -1,0 +1,490 @@
+# Table
+
+A responsive table component.
+
+## List
+
+Use the `ShadTable.list` widget to create a table from a two dimensional array of children.
+Use it just for **small** tables, because every child will be created.
+
+
+
+```dart
+
+
+
+const invoices = [
+  (
+    invoice: "INV001",
+    paymentStatus: "Paid",
+    totalAmount: r"$250.00",
+    paymentMethod: "Credit Card",
+  ),
+  (
+    invoice: "INV002",
+    paymentStatus: "Pending",
+    totalAmount: r"$150.00",
+    paymentMethod: "PayPal",
+  ),
+  (
+    invoice: "INV003",
+    paymentStatus: "Unpaid",
+    totalAmount: r"$350.00",
+    paymentMethod: "Bank Transfer",
+  ),
+  (
+    invoice: "INV004",
+    paymentStatus: "Paid",
+    totalAmount: r"$450.00",
+    paymentMethod: "Credit Card",
+  ),
+  (
+    invoice: "INV005",
+    paymentStatus: "Paid",
+    totalAmount: r"$550.00",
+    paymentMethod: "PayPal",
+  ),
+  (
+    invoice: "INV006",
+    paymentStatus: "Pending",
+    totalAmount: r"$200.00",
+    paymentMethod: "Bank Transfer",
+  ),
+  (
+    invoice: "INV007",
+    paymentStatus: "Unpaid",
+    totalAmount: r"$300.00",
+    paymentMethod: "Credit Card",
+  ),
+];
+
+class TablePage extends StatelessWidget {
+  const TablePage({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(
+            maxWidth: 600,
+            // added just to center the table vertically
+            maxHeight: 450,
+          ),
+          child: ShadTable.list(
+            header: const [
+              ShadTableCell.header(child: Text('Invoice')),
+              ShadTableCell.header(child: Text('Status')),
+              ShadTableCell.header(child: Text('Method')),
+              ShadTableCell.header(
+                alignment: Alignment.centerRight,
+                child: Text('Amount'),
+              ),
+            ],
+            footer: const [
+              ShadTableCell.footer(child: Text('Total')),
+              ShadTableCell.footer(child: Text('')),
+              ShadTableCell.footer(child: Text('')),
+              ShadTableCell.footer(
+                alignment: Alignment.centerRight,
+                child: Text(r'$2500.00'),
+              ),
+            ],
+            columnSpanExtent: (index) {
+              if (index == 2) return const FixedTableSpanExtent(130);
+              if (index == 3) {
+                return const MaxTableSpanExtent(
+                  FixedTableSpanExtent(120),
+                  RemainingTableSpanExtent(),
+                );
+              }
+              // uses the default value
+              return null;
+            },
+            children: invoices
+                .map(
+                  (invoice) => [
+                    ShadTableCell(
+                      child: Text(
+                        invoice.invoice,
+                        style: const TextStyle(
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                    ),
+                    ShadTableCell(child: Text(invoice.paymentStatus)),
+                    ShadTableCell(child: Text(invoice.paymentMethod)),
+                    ShadTableCell(
+                      alignment: Alignment.centerRight,
+                      child: Text(
+                        invoice.totalAmount,
+                      ),
+                    ),
+                  ],
+                ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+```
+
+
+
+## Builder
+
+You can also use a builder to create the table.
+This method is preferred for **large** tables because widgets are created on demand.
+Here it is the same table as above, but using a builder.
+
+```dart
+const invoices = [
+  [
+    "INV001",
+    "Paid",
+    "Credit Card",
+    r"$250.00",
+  ],
+  [
+    "INV002",
+    "Pending",
+    "PayPal",
+    r"$150.00",
+  ],
+  [
+    "INV003",
+    "Unpaid",
+    "Bank Transfer",
+    r"$350.00",
+  ],
+  [
+    "INV004",
+    "Paid",
+    "Credit Card",
+    r"$450.00",
+  ],
+  [
+    "INV005",
+    "Paid",
+    "PayPal",
+    r"$550.00",
+  ],
+  [
+    "INV006",
+    "Pending",
+    "Bank Transfer",
+    r"$200.00",
+  ],
+  [
+    "INV007",
+    "Unpaid",
+    "Credit Card",
+    r"$300.00",
+  ],
+];
+
+final headings = [
+  'Invoice',
+  'Status',
+  'Method',
+  'Amount',
+];
+
+class TableExample extends StatelessWidget {
+  const TableExample({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ShadTable(
+      columnCount: invoices[0].length,
+      rowCount: invoices.length,
+      header: (context, column) {
+        final isLast = column == headings.length - 1;
+        return ShadTableCell.header(
+          alignment: isLast ? Alignment.centerRight : null,
+          child: Text(headings[column]),
+        );
+      },
+      columnSpanExtent: (index) {
+        if (index == 2) return const FixedTableSpanExtent(150);
+        if (index == 3) {
+          return const MaxTableSpanExtent(
+            FixedTableSpanExtent(120),
+            RemainingTableSpanExtent(),
+          );
+        }
+        return null;
+      },
+      builder: (context, index) {
+        final invoice = invoices[index.row];
+        return ShadTableCell(
+          alignment: index.column == invoice.length - 1
+              ? Alignment.centerRight
+              : Alignment.centerLeft,
+          child: Text(
+            invoice[index.column],
+            style: index.column == 0
+                ? const TextStyle(fontWeight: FontWeight.w500)
+                : null,
+          ),
+        );
+      },
+      footer: (context, column) {
+        if (column == 0) {
+          return const ShadTableCell.footer(
+            child: Text(
+              'Total',
+              style: TextStyle(fontWeight: FontWeight.w500),
+            ),
+          );
+        }
+        if (column == 3) {
+          return const ShadTableCell.footer(
+            alignment: Alignment.centerRight,
+            child: Text(
+              r'$2500.00',
+            ),
+          );
+        }
+        return const ShadTableCell(child: SizedBox());
+      },
+    );
+  }
+}
+```
+
+## Example
+```dart
+import 'package:example/common/base_scaffold.dart';
+import 'package:flutter/material.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+const invoices = [
+  (
+    invoice: "INV001",
+    paymentStatus: "Paid",
+    totalAmount: r"$250.00",
+    paymentMethod: "Credit Card",
+  ),
+  (
+    invoice: "INV002",
+    paymentStatus: "Pending",
+    totalAmount: r"$150.00",
+    paymentMethod: "PayPal",
+  ),
+  (
+    invoice: "INV003",
+    paymentStatus: "Unpaid",
+    totalAmount: r"$350.00",
+    paymentMethod: "Bank Transfer",
+  ),
+  (
+    invoice: "INV004",
+    paymentStatus: "Paid",
+    totalAmount: r"$450.00",
+    paymentMethod: "Credit Card",
+  ),
+  (
+    invoice: "INV005",
+    paymentStatus: "Paid",
+    totalAmount: r"$550.00",
+    paymentMethod: "PayPal",
+  ),
+  (
+    invoice: "INV006",
+    paymentStatus: "Pending",
+    totalAmount: r"$200.00",
+    paymentMethod: "Bank Transfer",
+  ),
+  (
+    invoice: "INV007",
+    paymentStatus: "Unpaid",
+    totalAmount: r"$300.00",
+    paymentMethod: "Credit Card",
+  ),
+];
+
+class TablePage extends StatelessWidget {
+  const TablePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseScaffold(
+      appBarTitle: 'Table',
+      wrapChildrenInScrollable: false,
+      wrapSingleChildInColumn: false,
+      children: [
+        Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 600),
+            child: ShadTable.list(
+              header: const [
+                ShadTableCell.header(child: Text('Invoice')),
+                ShadTableCell.header(child: Text('Status')),
+                ShadTableCell.header(child: Text('Method')),
+                ShadTableCell.header(
+                  alignment: Alignment.centerRight,
+                  child: Text('Amount'),
+                ),
+              ],
+              footer: const [
+                ShadTableCell.footer(child: Text('Total')),
+                ShadTableCell.footer(child: Text('')),
+                ShadTableCell.footer(child: Text('')),
+                ShadTableCell.footer(
+                  alignment: Alignment.centerRight,
+                  child: Text(r'$2500.00'),
+                ),
+              ],
+              columnSpanExtent: (index) {
+                if (index == 2) return const FixedTableSpanExtent(130);
+                if (index == 3) {
+                  return const MaxTableSpanExtent(
+                    FixedTableSpanExtent(120),
+                    RemainingTableSpanExtent(),
+                  );
+                }
+                // uses the default value
+                return null;
+              },
+              children: invoices.map(
+                (invoice) => [
+                  ShadTableCell(
+                    child: Text(
+                      invoice.invoice,
+                      style: const TextStyle(
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ),
+                  ShadTableCell(child: Text(invoice.paymentStatus)),
+                  ShadTableCell(child: Text(invoice.paymentMethod)),
+                  ShadTableCell(
+                    alignment: Alignment.centerRight,
+                    child: Text(
+                      invoice.totalAmount,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/* With builder it will be
+const invoices = [
+  [
+    "INV001",
+    "Paid",
+    "Credit Card",
+    r"$250.00",
+  ],
+  [
+    "INV002",
+    "Pending",
+    "PayPal",
+    r"$150.00",
+  ],
+  [
+    "INV003",
+    "Unpaid",
+    "Bank Transfer",
+    r"$350.00",
+  ],
+  [
+    "INV004",
+    "Paid",
+    "Credit Card",
+    r"$450.00",
+  ],
+  [
+    "INV005",
+    "Paid",
+    "PayPal",
+    r"$550.00",
+  ],
+  [
+    "INV006",
+    "Pending",
+    "Bank Transfer",
+    r"$200.00",
+  ],
+  [
+    "INV007",
+    "Unpaid",
+    "Credit Card",
+    r"$300.00",
+  ],
+];
+
+final headings = [
+  'Invoice',
+  'Status',
+  'Method',
+  'Amount',
+];
+
+ShadTable(
+  columnCount: invoices[0].length,
+  rowCount: invoices.length,
+  header: (context, column) {
+    final isLast = column == headings.length - 1;
+    return ShadTableCell.header(
+      alignment: isLast ? Alignment.centerRight : null,
+      child: Text(headings[column]),
+    );
+  },
+  columnSpanExtent: (index) {
+    if (index == 2) return const FixedTableSpanExtent(150);
+    if (index == 3) {
+      return const MaxTableSpanExtent(
+        FixedTableSpanExtent(120),
+        RemainingTableSpanExtent(),
+      );
+    }
+    return null;
+  },
+  builder: (context, index) {
+    final invoice = invoices[index.row];
+    return ShadTableCell(
+      alignment: index.column == invoice.length - 1
+          ? Alignment.centerRight
+          : Alignment.centerLeft,
+      child: Text(
+        invoice[index.column],
+        style: index.column == 0
+            ? const TextStyle(fontWeight: FontWeight.w500)
+            : null,
+      ),
+    );
+  },
+  footer: (context, column) {
+    if (column == 0) {
+      return const ShadTableCell.footer(
+        child: Text(
+          'Total',
+          style: TextStyle(fontWeight: FontWeight.w500),
+        ),
+      );
+    }
+    if (column == 3) {
+      return const ShadTableCell.footer(
+        alignment: Alignment.centerRight,
+        child: Text(
+          r'$2500.00',
+        ),
+      );
+    }
+    return const ShadTableCell(child: SizedBox());
+  },
+)
+*/
+
+```

--- a/skills/shadcn-ui-flutter/components/tabs.md
+++ b/skills/shadcn-ui-flutter/components/tabs.md
@@ -1,0 +1,158 @@
+# Tabs
+
+A set of layered sections of content—known as tab panels—that are displayed one at a time.
+
+
+
+```dart
+class TabsExample extends StatelessWidget {
+  const TabsExample({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ShadTabs<String>(
+      value: 'account',
+      tabBarConstraints: const BoxConstraints(maxWidth: 400),
+      contentConstraints: const BoxConstraints(maxWidth: 400),
+      tabs: [
+        ShadTab(
+          value: 'account',
+          content: ShadCard(
+            title: const Text('Account'),
+            description: const Text(
+                "Make changes to your account here. Click save when you're done."),
+            footer: const ShadButton(child: Text('Save changes')),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const SizedBox(height: 16),
+                ShadInputFormField(
+                  label: const Text('Name'),
+                  initialValue: 'Ale',
+                ),
+                const SizedBox(height: 8),
+                ShadInputFormField(
+                  label: const Text('Username'),
+                  initialValue: 'nank1ro',
+                ),
+                const SizedBox(height: 16),
+              ],
+            ),
+          ),
+          child: const Text('Account'),
+        ),
+        ShadTab(
+          value: 'password',
+          content: ShadCard(
+            title: const Text('Password'),
+            description: const Text(
+                "Change your password here. After saving, you'll be logged out."),
+            footer: const ShadButton(child: Text('Save password')),
+            child: Column(
+              children: [
+                const SizedBox(height: 16),
+                ShadInputFormField(
+                  label: const Text('Current password'),
+                  obscureText: true,
+                ),
+                const SizedBox(height: 8),
+                ShadInputFormField(
+                  label: const Text('New password'),
+                  obscureText: true,
+                ),
+                const SizedBox(height: 16),
+              ],
+            ),
+          ),
+          child: const Text('Password'),
+        ),
+      ],
+    );
+  }
+}
+```
+
+## Example
+```dart
+import 'package:example/common/base_scaffold.dart';
+import 'package:flutter/material.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class TabsPage extends StatelessWidget {
+  const TabsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseScaffold(
+      appBarTitle: "Tabs",
+      wrapChildrenInScrollable: false,
+      wrapSingleChildInColumn: false,
+      alignment: Alignment.topCenter,
+      children: [
+        ShadTabs(
+          value: 'account',
+          tabBarConstraints: const BoxConstraints(maxWidth: 400),
+          contentConstraints: const BoxConstraints(maxWidth: 400),
+          onChanged: (value) => print(value),
+          tabs: [
+            ShadTab(
+              value: 'account',
+              content: ShadCard(
+                title: const Text('Account'),
+                description: const Text(
+                  "Make changes to your account here. Click save when you're done.",
+                ),
+                footer: const ShadButton(child: Text('Save changes')),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const SizedBox(height: 16),
+                    ShadInputFormField(
+                      label: const Text('Name'),
+                      initialValue: 'Ale',
+                    ),
+                    const SizedBox(height: 8),
+                    ShadInputFormField(
+                      label: const Text('Username'),
+                      initialValue: 'nank1ro',
+                    ),
+                    const SizedBox(height: 16),
+                  ],
+                ),
+              ),
+              child: const Text('Account'),
+            ),
+            ShadTab(
+              value: 'password',
+              content: ShadCard(
+                title: const Text('Password'),
+                description: const Text(
+                  "Change your password here. After saving, you'll be logged out.",
+                ),
+                footer: const ShadButton(child: Text('Save password')),
+                child: Column(
+                  children: [
+                    const SizedBox(height: 16),
+                    ShadInputFormField(
+                      label: const Text('Current password'),
+                      obscureText: true,
+                    ),
+                    const SizedBox(height: 8),
+                    ShadInputFormField(
+                      label: const Text('New password'),
+                      obscureText: true,
+                    ),
+                    const SizedBox(height: 16),
+                  ],
+                ),
+              ),
+              child: const Text('Password'),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+```

--- a/skills/shadcn-ui-flutter/components/textarea.md
+++ b/skills/shadcn-ui-flutter/components/textarea.md
@@ -1,0 +1,216 @@
+# Textarea
+
+Displays a form textarea or a component that looks like a textarea.
+
+
+
+```dart
+ConstrainedBox(
+  constraints: const BoxConstraints(maxWidth: 400),
+  child: const ShadTextarea(
+    placeholder: Text('Type your message here'),
+  ),
+),
+```
+
+
+
+## Form
+
+
+
+```dart
+ShadTextareaFormField(
+  id: 'bio',
+  label: const Text('Bio'),
+  placeholder:
+      const Text('Tell us a little bit about yourself'),
+  description: const Text(
+      'You can @mention other users and organizations.'),
+  validator: (v) {
+    if (v.length < 10) {
+      return 'Bio must be at least 10 characters.';
+    }
+    return null;
+  },
+)
+```
+
+## Example
+```dart
+import 'package:example/common/base_scaffold.dart';
+import 'package:example/common/properties/bool_property.dart';
+import 'package:flutter/material.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class TextareaPage extends StatefulWidget {
+  const TextareaPage({super.key});
+
+  @override
+  State<TextareaPage> createState() => _TextareaPageState();
+}
+
+class _TextareaPageState extends State<TextareaPage> {
+  bool enabled = true;
+  bool resizable = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseScaffold(
+      appBarTitle: 'Textarea',
+      editable: [
+        MyBoolProperty(
+          label: 'Enabled',
+          value: enabled,
+          onChanged: (v) => setState(() => enabled = v),
+        ),
+        MyBoolProperty(
+          label: 'Resizable',
+          value: resizable,
+          onChanged: (v) => setState(() => resizable = v),
+        ),
+      ],
+      children: [
+        ShadTextarea(
+          placeholder: const Text('Type your message here...'),
+          enabled: enabled,
+          resizable: resizable,
+          onChanged: (v) => print('Value changed: $v'),
+        ),
+      ],
+    );
+  }
+}
+
+```
+
+## Form Example
+```dart
+// ignore_for_file: avoid_print
+
+import 'dart:convert';
+
+import 'package:example/common/base_scaffold.dart';
+import 'package:example/common/properties/bool_property.dart';
+import 'package:example/common/properties/enum_property.dart';
+import 'package:example/common/properties/string_property.dart';
+import 'package:flutter/material.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class TextareaFormFieldPage extends StatefulWidget {
+  const TextareaFormFieldPage({super.key});
+
+  @override
+  State<TextareaFormFieldPage> createState() => _TextareaFormFieldPageState();
+}
+
+class _TextareaFormFieldPageState extends State<TextareaFormFieldPage> {
+  bool enabled = true;
+  var autovalidateMode = ShadAutovalidateMode.alwaysAfterFirstValidation;
+  String? initialValue;
+  Map<Object, dynamic> formValue = {};
+  final formKey = GlobalKey<ShadFormState>();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+
+    return ShadForm(
+      key: formKey,
+      enabled: enabled,
+      autovalidateMode: autovalidateMode,
+      initialValue: {if (initialValue != null) 'bio': initialValue},
+      child: BaseScaffold(
+        appBarTitle: 'TextareaFormField',
+        editable: [
+          MyBoolProperty(
+            label: 'Enabled',
+            value: enabled,
+            onChanged: (value) => setState(() => enabled = value),
+          ),
+          MyEnumProperty(
+            label: 'autovalidateMode',
+            value: autovalidateMode,
+            values: ShadAutovalidateMode.values,
+            onChanged: (value) {
+              if (value != null) {
+                setState(() => autovalidateMode = value);
+              }
+            },
+          ),
+          MyStringProperty(
+            label: 'Form Initial Value',
+            initialValue: initialValue,
+            placeholder: const Text('Enter your bio...'),
+            onChanged: (value) {
+              formKey.currentState!.setFieldValue('bio', value);
+            },
+          ),
+        ],
+        children: [
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 500),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                ShadTextareaFormField(
+                  id: 'bio',
+                  label: const Text('Bio'),
+                  placeholder: const Text('Tell us about yourself...'),
+                  minHeight: 100,
+                  maxHeight: 250,
+                  validator: (v) {
+                    if (v.trim().isEmpty) return 'Bio cannot be empty.';
+                    if (v.length < 10) {
+                      return 'Bio must be at least 10 characters.';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 16),
+                ShadButton(
+                  child: const Text('Submit'),
+                  onPressed: () {
+                    if (formKey.currentState!.saveAndValidate()) {
+                      ShadToaster.of(context).show(
+                        ShadToast(title: Text('Form submitted successfully')),
+                      );
+                      setState(() {
+                        formValue = formKey.currentState!.value;
+                      });
+                    } else {
+                      ShadToaster.of(context).show(
+                        ShadToast.destructive(
+                          title: Text('Please correct the errors in the form'),
+                        ),
+                      );
+                    }
+                  },
+                ),
+                if (formValue.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 24, left: 12),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text('FormValue', style: theme.textTheme.p),
+                        const SizedBox(height: 4),
+                        SelectableText(
+                          const JsonEncoder.withIndent(
+                            '    ',
+                          ).convert(formValue),
+                          style: theme.textTheme.small,
+                        ),
+                      ],
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+```

--- a/skills/shadcn-ui-flutter/components/time-picker.md
+++ b/skills/shadcn-ui-flutter/components/time-picker.md
@@ -1,0 +1,263 @@
+# Time Picker
+
+A time picker component.
+
+
+
+```dart
+class PrimaryTimePicker extends StatelessWidget {
+  const PrimaryTimePicker({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: 600),
+      child: const ShadTimePicker(
+        trailing: Padding(
+          padding: EdgeInsets.only(left: 8, top: 14),
+          child: Icon(LucideIcons.clock4),
+        ),
+      ),
+    );
+  }
+}
+```
+
+
+
+## Form
+
+
+
+```dart
+ShadTimePickerFormField(
+  label: const Text('Pick a time'),
+  onChanged: print,
+  description:
+      const Text('The time of the day you want to pick'),
+  validator: (v) => v == null ? 'A time is required' : null,
+)
+```
+
+
+
+## ShadTimePickerFormField.period
+
+
+
+```dart
+ShadTimePickerFormField.period(
+  label: const Text('Pick a time'),
+  onChanged: print,
+  description:
+      const Text('The time of the day you want to pick'),
+  validator: (v) => v == null ? 'A time is required' : null,
+),
+```
+
+## Example
+```dart
+import 'package:example/common/base_scaffold.dart';
+import 'package:example/common/properties/bool_property.dart';
+import 'package:flutter/material.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class TimePickerPage extends StatefulWidget {
+  const TimePickerPage({super.key});
+
+  @override
+  State<TimePickerPage> createState() => _TimePickerPageState();
+}
+
+class _TimePickerPageState extends State<TimePickerPage> {
+  bool showHours = true;
+  bool showMinutes = true;
+  bool showSeconds = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseScaffold(
+      appBarTitle: 'TimePicker',
+      editable: [
+        MyBoolProperty(
+          label: ' Show Hours',
+          value: showHours,
+          enabled: showMinutes || showSeconds,
+          onChanged: (v) => setState(() => showHours = v),
+        ),
+        MyBoolProperty(
+          label: ' Show Minutes',
+          value: showMinutes,
+          enabled: showHours || showSeconds,
+          onChanged: (v) => setState(() => showMinutes = v),
+        ),
+        MyBoolProperty(
+          label: ' Show Seconds',
+          enabled: showHours || showMinutes,
+          value: showSeconds,
+          onChanged: (v) => setState(() => showSeconds = v),
+        ),
+      ],
+      children: [
+        ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 600),
+          child: ShadTimePicker(
+            showHours: showHours,
+            showMinutes: showMinutes,
+            showSeconds: showSeconds,
+            trailing: const Padding(
+              padding: EdgeInsets.only(left: 8, top: 14),
+              child: Icon(LucideIcons.clock4),
+            ),
+            onChanged: (time) {
+              print('time: $time');
+            },
+          ),
+        ),
+        ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 600),
+          child: ShadTimePicker.period(
+            showHours: showHours,
+            showMinutes: showMinutes,
+            showSeconds: showSeconds,
+            crossAxisAlignment: WrapCrossAlignment.end,
+            onChanged: (time) {
+              print('time: $time');
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+```
+
+## Form Example
+```dart
+// ignore_for_file: avoid_print
+
+import 'package:example/common/base_scaffold.dart';
+import 'package:example/common/properties/bool_property.dart';
+import 'package:example/common/properties/enum_property.dart';
+import 'package:flutter/material.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class TimePickerFormFieldPage extends StatefulWidget {
+  const TimePickerFormFieldPage({super.key});
+
+  @override
+  State<TimePickerFormFieldPage> createState() =>
+      _TimePickerFormFieldPageState();
+}
+
+class _TimePickerFormFieldPageState extends State<TimePickerFormFieldPage> {
+  bool enabled = true;
+  var autovalidateMode = ShadAutovalidateMode.alwaysAfterFirstValidation;
+  Map<Object, dynamic> formValue = {};
+  final formKey = GlobalKey<ShadFormState>();
+  bool showHours = true;
+  bool showMinutes = true;
+  bool showSeconds = true;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = ShadTheme.of(context);
+    return ShadForm(
+      key: formKey,
+      enabled: enabled,
+      autovalidateMode: autovalidateMode,
+      child: BaseScaffold(
+        appBarTitle: 'TimePickerFormField',
+        editable: [
+          MyBoolProperty(
+            label: 'Enabled',
+            value: enabled,
+            onChanged: (value) => setState(() => enabled = value),
+          ),
+          MyEnumProperty(
+            label: 'autovalidateMode',
+            value: autovalidateMode,
+            values: ShadAutovalidateMode.values,
+            onChanged: (value) {
+              if (value != null) {
+                setState(() => autovalidateMode = value);
+              }
+            },
+          ),
+          MyBoolProperty(
+            label: ' Show Hours',
+            value: showHours,
+            enabled: showMinutes || showSeconds,
+            onChanged: (v) => setState(() => showHours = v),
+          ),
+          MyBoolProperty(
+            label: ' Show Minutes',
+            value: showMinutes,
+            enabled: showHours || showSeconds,
+            onChanged: (v) => setState(() => showMinutes = v),
+          ),
+          MyBoolProperty(
+            label: ' Show Seconds',
+            enabled: showHours || showMinutes,
+            value: showSeconds,
+            onChanged: (v) => setState(() => showSeconds = v),
+          ),
+        ],
+        children: [
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 350),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                ShadTimePickerFormField(
+                  id: 'time',
+                  showHours: showHours,
+                  showMinutes: showMinutes,
+                  showSeconds: showSeconds,
+                  label: const Text('Pick a time'),
+                  onChanged: print,
+                  description: const Text(
+                    'The time of the day you want to pick',
+                  ),
+                  validator: (v) => v == null ? 'A time is required' : null,
+                ),
+                const SizedBox(height: 16),
+                ShadButton(
+                  child: const Text('Submit'),
+                  onPressed: () {
+                    print('submitted');
+                    if (formKey.currentState!.saveAndValidate()) {
+                      setState(() {
+                        formValue = formKey.currentState!.value;
+                      });
+                    } else {
+                      print('validation failed');
+                    }
+                  },
+                ),
+                if (formValue.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 24, left: 12),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text('FormValue', style: theme.textTheme.p),
+                        const SizedBox(height: 4),
+                        SelectableText(
+                          formValue.toString(),
+                          style: theme.textTheme.small,
+                        ),
+                      ],
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+```

--- a/skills/shadcn-ui-flutter/components/toast.md
+++ b/skills/shadcn-ui-flutter/components/toast.md
@@ -1,0 +1,208 @@
+# Toast
+
+A succinct message that is displayed temporarily.
+
+
+
+```dart
+ShadButton.outline(
+  child: const Text('Add to calendar'),
+  onPressed: () {
+    ShadToaster.of(context).show(
+      ShadToast(
+        title: const Text('Scheduled: Catch up'),
+        description:
+            const Text('Friday, February 10, 2023 at 5:57 PM'),
+        action: ShadButton.outline(
+          child: const Text('Undo'),
+          onPressed: () => ShadToaster.of(context).hide(),
+        ),
+      ),
+    );
+  },
+),
+```
+
+
+
+## Simple
+
+
+
+```dart
+ShadButton.outline(
+  child: const Text('Show Toast'),
+  onPressed: () {
+    ShadToaster.of(context).show(
+      const ShadToast(
+        description: Text('Your message has been sent.'),
+      ),
+    );
+  },
+),
+```
+
+
+
+## With Title
+
+
+
+```dart
+ShadButton.outline(
+  child: const Text('Show Toast'),
+  onPressed: () {
+    ShadToaster.of(context).show(
+      const ShadToast(
+        title: Text('Uh oh! Something went wrong'),
+        description:
+            Text('There was a problem with your request'),
+      ),
+    );
+  },
+),
+```
+
+
+
+## With Action
+
+
+
+```dart
+ShadButton.outline(
+  child: const Text('Show Toast'),
+  onPressed: () {
+    ShadToaster.of(context).show(
+      ShadToast(
+        title: const Text('Uh oh! Something went wrong'),
+        description:
+            const Text('There was a problem with your request'),
+        action: ShadButton.outline(
+          child: const Text('Try again'),
+          onPressed: () => ShadToaster.of(context).hide(),
+        ),
+      ),
+    );
+  },
+),
+```
+
+
+
+## Destructive
+
+
+
+```dart
+final theme = ShadTheme.of(context);
+
+ShadButton.outline(
+  child: const Text('Show Toast'),
+  onPressed: () {
+    ShadToaster.of(context).show(
+      ShadToast.destructive(
+        title: const Text('Uh oh! Something went wrong'),
+        description:
+            const Text('There was a problem with your request'),
+        action: ShadButton.destructive(
+          child: const Text('Try again'),
+          decoration: ShadDecoration(
+            border: ShadBorder.all(
+              color: theme.colorScheme.destructiveForeground,
+              width: 1,
+            ),
+          ),
+          onPressed: () => ShadToaster.of(context).hide(),
+        ),
+      ),
+    );
+  },
+),
+```
+
+## Example
+```dart
+import 'package:example/common/base_scaffold.dart';
+import 'package:example/common/properties/enum_property.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+enum Alignm {
+  topRight,
+  topLeft,
+  bottomRight,
+  bottomLeft,
+  centerRight,
+  centerLeft,
+  center,
+  topCenter,
+  bottomCenter;
+
+  Alignment toAlignment() {
+    return switch (this) {
+      topRight => Alignment.topRight,
+      topLeft => Alignment.topLeft,
+      bottomRight => Alignment.bottomRight,
+      bottomLeft => Alignment.bottomLeft,
+      centerRight => Alignment.centerRight,
+      centerLeft => Alignment.centerLeft,
+      center => Alignment.center,
+      topCenter => Alignment.topCenter,
+      bottomCenter => Alignment.bottomCenter,
+    };
+  }
+}
+
+class ToastPage extends StatefulWidget {
+  const ToastPage({super.key});
+
+  @override
+  State<ToastPage> createState() => _ToastPageState();
+}
+
+class _ToastPageState extends State<ToastPage> {
+  var alignment = Alignm.bottomRight;
+  @override
+  Widget build(BuildContext context) {
+    return BaseScaffold(
+      appBarTitle: 'Toast',
+      editable: [
+        MyEnumProperty<Alignm>(
+          label: 'Alignment',
+          value: alignment,
+          values: Alignm.values,
+          onChanged: (v) {
+            if (v != null) {
+              setState(() {
+                alignment = v;
+              });
+            }
+          },
+        ),
+      ],
+      children: [
+        ShadButton.outline(
+          child: const Text('Add to calendar'),
+          onPressed: () {
+            final toaster = ShadToaster.of(context);
+            toaster.show(
+              ShadToast(
+                alignment: alignment.toAlignment(),
+                title: const Text('Scheduled: Catch up'),
+                description: const Text('Friday, February 10, 2023 at 5:57 PM'),
+                action: ShadButton.outline(
+                  child: const Text('Undo'),
+                  onPressed: () => toaster.hide(),
+                ),
+              ),
+            );
+          },
+        ),
+      ],
+    );
+  }
+}
+
+```

--- a/skills/shadcn-ui-flutter/components/tooltip.md
+++ b/skills/shadcn-ui-flutter/components/tooltip.md
@@ -1,0 +1,60 @@
+# Tooltip
+
+A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it.
+
+
+```dart
+ShadTooltip(
+  builder: (context) => const Text('Add to library'),
+  child: ShadButton.outline(
+    child: const Text('Hover/Focus'),
+    onPressed: () {},
+  ),
+),
+```
+
+
+The tooltip works on hover only if the child uses a `ShadGestureDetector`. If you don't use a `ShadButton` or something similar that implements `ShadGestureDetector` hover will not work.
+If, for example, you want to just show an image as child, wrap it with `ShadGestureDetector` to make it working.
+
+## Example
+```dart
+import 'package:example/common/base_scaffold.dart';
+import 'package:flutter/widgets.dart';
+import 'package:shadcn_ui/shadcn_ui.dart';
+
+class TooltipPage extends StatefulWidget {
+  const TooltipPage({super.key});
+
+  @override
+  State<TooltipPage> createState() => _TooltipPageState();
+}
+
+class _TooltipPageState extends State<TooltipPage> {
+  final focusNode = FocusNode();
+
+  @override
+  void dispose() {
+    focusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BaseScaffold(
+      appBarTitle: 'Tooltip',
+      children: [
+        ShadTooltip(
+          focusNode: focusNode,
+          builder: (context) => const Text('Add to library'),
+          child: ShadButton.outline(
+            focusNode: focusNode,
+            child: const Text('Hover/Focus'),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+```

--- a/skills/shadcn-ui-flutter/guides/decorator.md
+++ b/skills/shadcn-ui-flutter/guides/decorator.md
@@ -1,0 +1,49 @@
+Decorates most of the components of the library using a `ShadDecoration` handled by the `ShadDecorator` component.
+
+## Default
+
+```dart
+ShadDecoration(
+  secondaryBorder: ShadBorder.all(
+    padding: const EdgeInsets.all(4),
+    width: 0,
+  ),
+  secondaryFocusedBorder: ShadBorder.all(
+    width: 2,
+    color: colorScheme.ring,
+    radius: radius.add(radius / 2),
+    padding: const EdgeInsets.all(2),
+  ),
+  labelStyle: textTheme.muted.copyWith(
+    fontWeight: FontWeight.w500,
+    color: colorScheme.foreground,
+  ),
+  errorStyle: textTheme.muted.copyWith(
+    fontWeight: FontWeight.w500,
+    color: colorScheme.destructive,
+  ),
+  labelPadding: const EdgeInsets.only(bottom: 8),
+  descriptionStyle: textTheme.muted,
+  descriptionPadding: const EdgeInsets.only(top: 8),
+  errorPadding: const EdgeInsets.only(top: 8),
+  errorLabelStyle: textTheme.muted.copyWith(
+    fontWeight: FontWeight.w500,
+    color: colorScheme.destructive,
+  ),
+);
+```
+
+## Secondary Border
+
+By default, a secondary border is drawn around the focusable components.
+If you want to disable it and instead make bolder the primary border, you just need to add the `disableSecondaryBorder` property to the theme.
+
+```dart
+ShadThemeData(
+  // Disables the secondary border
+  disableSecondaryBorder: true,
+),
+```
+
+Be aware, this change is not recommended, as it may lead to accessibility issues.
+The secondary border is there to help users understand which component is focused.

--- a/skills/shadcn-ui-flutter/guides/interop.md
+++ b/skills/shadcn-ui-flutter/guides/interop.md
@@ -1,0 +1,161 @@
+# Interoperability
+
+## Shadcn + Material
+
+We are the first Flutter UI library to allow shadcn components to be used simultaneously with Material components.
+The setup is simple:
+
+```diff lang="dart"
+import 'package:shadcn_ui/shadcn_ui.dart';
++ import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+-    return ShadApp();
++    return ShadApp.custom(
++      themeMode: ThemeMode.dark,
++      darkTheme: ShadThemeData(
++        brightness: Brightness.dark,
++        colorScheme: const ShadSlateColorScheme.dark(),
++      ),
++      appBuilder: (context) {
++        return MaterialApp(
++          theme: Theme.of(context),
++          localizationsDelegates: const [
++            GlobalShadLocalizations.delegate,
++            GlobalMaterialLocalizations.delegate,
++            GlobalCupertinoLocalizations.delegate,
++            GlobalWidgetsLocalizations.delegate,
++          ],
++          builder: (context, child) {
++            return ShadAppBuilder(child: child!);
++          },
++        );
++      },
++    );
+  }
+```
+
+:::tip
+If you need to use the `Router` instead of the `Navigator`, use `MaterialApp.router`.
+:::
+
+---
+
+The default Material `ThemeData` created by `ShadApp` is:
+
+```dart
+ThemeData(
+  fontFamily: themeData.textTheme.family,
+  extensions: themeData.extensions,
+  colorScheme: ColorScheme(
+    brightness: themeData.brightness,
+    primary: themeData.colorScheme.primary,
+    onPrimary: themeData.colorScheme.primaryForeground,
+    secondary: themeData.colorScheme.secondary,
+    onSecondary: themeData.colorScheme.secondaryForeground,
+    error: themeData.colorScheme.destructive,
+    onError: themeData.colorScheme.destructiveForeground,
+    surface: themeData.colorScheme.background,
+    onSurface: themeData.colorScheme.foreground,
+  ),
+  scaffoldBackgroundColor: themeData.colorScheme.background,
+  brightness: themeData.brightness,
+  dividerTheme: DividerThemeData(
+    color: themeData.colorScheme.border,
+    thickness: 1,
+  ),
+  textSelectionTheme: TextSelectionThemeData(
+    cursorColor: themeData.colorScheme.primary,
+    selectionColor: themeData.colorScheme.selection,
+    selectionHandleColor: themeData.colorScheme.primary,
+  ),
+  iconTheme: IconThemeData(
+    size: 16,
+    color: themeData.colorScheme.foreground,
+  ),
+  scrollbarTheme: ScrollbarThemeData(
+    crossAxisMargin: 1,
+    mainAxisMargin: 1,
+    thickness: const WidgetStatePropertyAll(8),
+    radius: const Radius.circular(999),
+    thumbColor: WidgetStatePropertyAll(themeData.colorScheme.border),
+  ),
+),
+```
+
+:::note
+Use `Theme.of(context).copyWith(...)` to override the default theme, without losing the default values provided by shadcn_ui.
+:::
+
+## Shadcn + Cupertino
+
+If you need to use shadcn components with Cupertino components, use `CupertinoApp` instead of `MaterialApp`, like you are already used to.
+
+```diff lang="dart"
+import 'package:shadcn_ui/shadcn_ui.dart';
++ import 'package:flutter/cupertino.dart';
++ import 'package:flutter_localizations/flutter_localizations.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+-    return ShadApp();
++    return ShadApp.custom(
++      themeMode: ThemeMode.dark,
++      darkTheme: ShadThemeData(
++        brightness: Brightness.dark,
++        colorScheme: const ShadSlateColorScheme.dark(),
++      ),
++      appBuilder: (context) {
++        return CupertinoApp(
++          theme: CupertinoTheme.of(context),
++          localizationsDelegates: const [
++            GlobalShadLocalizations.delegate,
++            DefaultMaterialLocalizations.delegate,
++            DefaultCupertinoLocalizations.delegate,
++            DefaultWidgetsLocalizations.delegate,
++          ],
++          builder: (context, child) {
++            return ShadAppBuilder(child: child!);
++          },
++        );
++      },
++    );
+  }
+```
+
+:::tip
+If you need to use the `Router` instead of the `Navigator`, use `CupertinoApp.router`.
+:::
+
+---
+
+The default `CupertinoThemeData` created by `ShadApp` is:
+
+```dart
+CupertinoThemeData(
+  primaryColor: themeData.colorScheme.primary,
+  primaryContrastingColor: themeData.colorScheme.primaryForeground,
+  scaffoldBackgroundColor: themeData.colorScheme.background,
+  barBackgroundColor: themeData.colorScheme.primary,
+  brightness: themeData.brightness,
+),
+```
+
+:::note
+Use `CupertinoTheme.of(context).copyWith(...)` to override the default theme, without losing the default values provided by shadcn_ui.
+:::

--- a/skills/shadcn-ui-flutter/guides/responsive.md
+++ b/skills/shadcn-ui-flutter/guides/responsive.md
@@ -1,0 +1,65 @@
+In *shadcn_ui* the responsiveness is an important part of the library.
+
+The `ShadTheme` supports a customizable set of breakpoints.
+
+## Default
+
+```dart
+ShadThemeData(
+  breakpoints: ShadBreakpoints(
+    tn: 0, // tiny
+    sm: 640, // small
+    md: 768, // medium
+    lg: 1024, // large
+    xl: 1280, // extra large
+    xxl: 1536, // extra extra large
+  ),
+);
+```
+
+## Current breakpoint
+
+To get the current breakpoint you can use `ShadResponsiveBuilder` or `context.breakpoint`, eg:
+
+```dart
+
+ShadResponsiveBuilder(
+  builder: (context, breakpoint) {
+    final sm = breakpoint >= ShadTheme.of(context).breakpoints.sm;
+    ...
+  },
+),
+```
+
+which is equivalent to:
+
+```dart
+final sm = context.breakpoint >= ShadTheme.of(context).breakpoints.sm;
+
+```
+
+In Tailwind CSS, it's common to say that *sm* is not for small screens, but will target also the largest sizes if you don't provide a larger breakpoint.
+
+That's why I'm using the `>=` operator.
+
+If you just want to check if you're in a specific breakpoint, use the `==` operator.
+
+## Sealed class
+
+The breakpoint returned is a sealed class so you can switch any size.
+
+```dart
+
+ShadResponsiveBuilder(
+  builder: (context, breakpoint) {
+    return switch (breakpoint) {
+      ShadBreakpointTN() => const Text('Tiny'),
+      ShadBreakpointSM() => const Text('Small'),
+      ShadBreakpointMD() => const Text('Medium'),
+      ShadBreakpointLG() => const Text('Large'),
+      ShadBreakpointXL() => const Text('Extra Large'),
+      ShadBreakpointXXL() => const Text('Extra Extra Large'),
+    };
+  },
+),
+```

--- a/skills/shadcn-ui-flutter/guides/theming.md
+++ b/skills/shadcn-ui-flutter/guides/theming.md
@@ -1,0 +1,141 @@
+Defines the theme and color scheme for the app.
+
+The supported color schemes are:
+
+- blue
+- gray
+- green
+- neutral
+- orange
+- red
+- rose
+- slate
+- stone
+- violet
+- yellow
+- zinc
+
+## Usage
+
+```diff lang="dart"
+
+
+@override
+Widget build(BuildContext context) {
+  return ShadApp(
++    darkTheme: ShadThemeData(
++      brightness: Brightness.dark,
++      colorScheme: const ShadSlateColorScheme.dark(),
++    ),
+    child: ...
+  );
+}
+```
+
+You can override specific properties of the selected theme/color scheme:
+
+```diff lang="dart"
+
+
+@override
+Widget build(BuildContext context) {
+  return ShadApp(
+    darkTheme: ShadThemeData(
+        brightness: Brightness.dark,
+        colorScheme: const ShadSlateColorScheme.dark(
++          background: Colors.blue,
+        ),
++        primaryButtonTheme: const ShadButtonTheme(
++          backgroundColor: Colors.cyan,
++        ),
+      ),
+    ),
+    child: ...
+  );
+}
+```
+
+You can also create your custom color scheme, just extend the `ShadColorScheme` class and pass all the properties.
+
+
+## ShadColorScheme.fromName
+
+If you want to allow the user to change the default shadcn themes, I suggest using `ShadColorScheme.fromName`.
+
+```dart
+// available color scheme names
+final shadThemeColors = [
+  'blue',
+  'gray',
+  'green',
+  'neutral',
+  'orange',
+  'red',
+  'rose',
+  'slate',
+  'stone',
+  'violet',
+  'yellow',
+  'zinc',
+];
+
+final lightColorScheme = ShadColorScheme.fromName('blue');
+final darkColorScheme = ShadColorScheme.fromName('slate', brightness: Brightness.dark);
+```
+
+In this way you can easily create a select to change the color scheme, for example:
+
+```dart
+
+
+
+// Somewhere in your app
+ShadSelect<String>(
+  initialValue: 'slate',
+  maxHeight: 200,
+  options: shadThemeColors.map(
+    (option) => ShadOption(
+      value: option,
+      child: Text(
+        option.capitalizeFirst(),
+      ),
+    ),
+  ),
+  selectedOptionBuilder: (context, value) {
+    return Text(value.capitalizeFirst());
+  },
+  onChanged: (value) {
+    // rebuild the app using your state management solution
+  },
+),
+```
+
+For example I'm using solidart as state management, here it is the example code used to rebuild the app widget when the user changes the theme mode. Check the "Toggle Theme" example at <https://solidart.mariuti.com/examples>
+
+The same can be done for the color scheme, using a `Signal<String>()`
+
+## Extend with custom colors
+
+You can extend the `ShadColorScheme` with your own custom colors by using the `custom` parameter.
+```diff lang="dart"
+return ShadApp(
+  theme: ShadThemeData(
++    colorScheme: const ShadZincColorScheme.light(
++      custom: {
++        'myCustomColor': Color.fromARGB(255, 177, 4, 196),
++      },
++    ),
+  ),
+);
+```
+
+Then you can access it like this `ShadTheme.of(context).colorScheme.custom['myCustomColor']!`.
+
+Or you can create an extension on `ShadColorScheme` to make it easier to access:
+```dart
+extension CustomColorExtension on ShadColorScheme {
+  Color get myCustomColor => custom['myCustomColor']!;
+}
+```
+
+In this way you can access it like other colors `ShadTheme.of(context).colorScheme.myCustomColor`.

--- a/skills/shadcn-ui-flutter/guides/typography.md
+++ b/skills/shadcn-ui-flutter/guides/typography.md
@@ -1,0 +1,231 @@
+Styles for headings, paragraphs, lists...etc
+
+## h1Large
+
+
+ ```dart
+Text(
+  'Taxing Laughter: The Joke Tax Chronicles',
+  style: ShadTheme.of(context).textTheme.h1Large,
+)
+```
+
+
+## h1
+
+
+ ```dart
+Text(
+  'Taxing Laughter: The Joke Tax Chronicles',
+  style: ShadTheme.of(context).textTheme.h1,
+)
+```
+
+
+## h2
+
+
+ ```dart
+Text(
+  'The People of the Kingdom',
+  style: ShadTheme.of(context).textTheme.h2,
+)
+```
+
+
+## h3
+
+
+ ```dart
+Text(
+  'The Joke Tax',
+  style: ShadTheme.of(context).textTheme.h3,
+)
+```
+
+
+## h4
+
+
+ ```dart
+Text(
+  'The king, seeing how much happier his subjects were, realized the error of his ways and repealed the joke tax.',
+  style: ShadTheme.of(context).textTheme.h4,
+)
+```
+
+
+## p
+
+
+ ```dart
+Text(
+  'The king, seeing how much happier his subjects were, realized the error of his ways and repealed the joke tax.',
+  style: ShadTheme.of(context).textTheme.p,
+)
+```
+
+
+## Blockquote
+
+
+ ```dart
+Text(
+  '"After all," he said, "everyone enjoys a good joke, so it\'s only fair that they should pay for the privilege."',
+  style: ShadTheme.of(context).textTheme.blockquote,
+)
+```
+
+
+## Table
+
+
+ ```dart
+Text(
+  "King's Treasury",
+  style: ShadTheme.of(context).textTheme.table,
+)
+```
+
+
+## List
+
+
+ ```dart
+Text(
+  '1st level of puns: 5 gold coins',
+  style: ShadTheme.of(context).textTheme.list,
+)
+```
+
+
+## Lead
+
+
+ ```dart
+Text(
+  'A modal dialog that interrupts the user with important content and expects a response.',
+  style: ShadTheme.of(context).textTheme.lead,
+)
+```
+
+
+## Large
+
+
+ ```dart
+Text(
+  'Are you absolutely sure?',
+  style: ShadTheme.of(context).textTheme.large,
+)
+```
+
+
+## Small
+
+
+ ```dart
+Text(
+  'Email address',
+  style: ShadTheme.of(context).textTheme.small,
+)
+```
+
+
+## Muted
+
+
+ ```dart
+Text(
+  'Enter your email address.',
+  style: ShadTheme.of(context).textTheme.muted,
+)
+```
+
+
+## Custom font family
+
+By default Shadcn UI uses [Geist](https://vercel.com/font) as default font family.
+To change it, add the local font to your project, for example in the `/fonts` directory.
+Then update your `pubspec.yaml` with something like this:
+
+```diff lang="yaml"
+flutter:
++  fonts:
++    - family: UbuntuMono
++      fonts:
++        - asset: fonts/UbuntuMono-Regular.ttf
++        - asset: fonts/UbuntuMono-Italic.ttf
++          style: italic
++        - asset: fonts/UbuntuMono-Bold.ttf
++          weight: 700
++        - asset: fonts/UbuntuMono-BoldItalic.ttf
++          weight: 700
++          style: italic
+```
+
+Then in your `ShadApp` update the `ShadTextTheme`:
+```diff lang="dart"
+return ShadApp(
+  debugShowCheckedModeBanner: false,
+  themeMode: themeMode,
+  routes: routes,
+  theme: ShadThemeData(
+    brightness: Brightness.light,
+    colorScheme: const ShadZincColorScheme.light(),
++    textTheme: ShadTextTheme(
++      colorScheme: const ShadZincColorScheme.light(),
++      family: 'UbuntuMono',
++    ),
+  ),
+  ...
+);
+```
+
+## Google font
+
+Install the [google_fonts](https://pub.dev/packages/google_fonts) package.
+Then add the google font to your `ShadApp`:
+```diff lang="dart"
+return ShadApp(
+  debugShowCheckedModeBanner: false,
+  themeMode: themeMode,
+  routes: routes,
+  theme: ShadThemeData(
+    brightness: Brightness.light,
+    colorScheme: const ShadZincColorScheme.light(),
++    textTheme: ShadTextTheme.fromGoogleFont(GoogleFonts.poppins),
+  ),
+  ...
+);
+```
+
+## Extend with custom styles
+
+You can extend the `ShadTextTheme` with your own custom styles by using the `custom` parameter.
+```diff lang="dart"
+return ShadApp(
+  theme: ShadThemeData(
++    textTheme: ShadTextTheme(
++      custom: {
++        'myCustomStyle': const TextStyle(
++          fontSize: 16,
++          fontWeight: FontWeight.w400,
++          color: Colors.blue,
++        ),
++      },
++    ),
+  ),
+);
+```
+
+Then you can access it like this `ShadTheme.of(context).textTheme.custom['myCustomStyle']!`.
+
+Or you can create an extension on `ShadTextTheme` to make it easier to access:
+```dart
+extension CustomStyleExtension on ShadTextTheme {
+  TextStyle get myCustomStyle => custom['myCustomStyle']!;
+}
+```
+
+In this way you can access it like other styles `ShadTheme.of(context).textTheme.myCustomStyle`.


### PR DESCRIPTION
Following the [spec](https://agentskills.io/specification), I created a script that creates a skill in the top level skills directory based on docs and examples. The script is in dart and can be run any time to regenerate the skill.

Users can add the skills from this repo with any tool that supports skills like https://skills.sh

```
npx skills add nank1ro/flutter-shadcn-ui
```

Also had promising results with a one shot prompt using Gemini 3 Flash for a coffee app and the one skill.

Prompt: "Create a shadcn flutter app for a POS coffee shop system. Seed it with products, inventory and cart screen.  Add an ability to refund orders, and look up custom history. and also have charts for sales totals"

<img width="1669" height="1198" alt="Screenshot 2026-04-10 at 12 50 18 PM" src="https://github.com/user-attachments/assets/f080810f-a12d-46f6-9275-8709ba20b3b7" />

The skill is designed so that only important context is disclosed with the top level skill and the agent can look up each component with examples. I also included various guides that should be useful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a SKILL page with a component catalog and Flutter setup example.

* **Documentation**
  * Added comprehensive documentation for 30+ shadcn-ui Flutter components with runnable examples.
  * Added guides: theming, typography, responsive design, Material/Cupertino interop, and decorator.
  * Updated README and docs index to include Agent Skills install tip and integration note.

* **Chores**
  * Organized skill documentation into components and guides for easier discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->