### PR TITLE
fix(mouse_area): add hasSize check to MouseAreaSurfaceRenderBox hitTest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.53.6
+
+- **FIX**: Add `!hasSize` check to `MouseAreaSurfaceRenderBox.hitTest` to prevent assertion failure during early pointer events on desktop.
+
 ## 0.53.5
 
 - **FIX**: `ShadDatePicker` now correctly falls back to `datePickerTheme.buttonDecoration` when no explicit `buttonDecoration` is provided.
@@ -415,7 +419,7 @@
 ## 0.31.0
 
 - **FEAT**: Modify the `ShadTooltip` component and its hover strategies to work on mobile on tap without a long press.
-- **FEAT**: Add `ShadHoverStrategy.onTapOutside` to trigger unhover when tapping outside the widget. 
+- **FEAT**: Add `ShadHoverStrategy.onTapOutside` to trigger unhover when tapping outside the widget.
 - **FEAT**: Add `ShadHoverStrategy.onTap` to trigger hover/unhover when tapping inside the widget.
 - **FEAT**: Now if an hover strategy is present in both `hoverStrategies.hover` and `hoverStrategies.unhover`, the hover will be toggled.
 
@@ -442,7 +446,7 @@
 ## 0.30.1
 
 - **FIX**: Fix `ShadResizable` on RTL (for real this time).
-- **CHORE**: Bump min Flutter SDK version to `3.35.0` to support `FormField.onReset` and `Brightness` from `'package:flutter/widgets.dart'` 
+- **CHORE**: Bump min Flutter SDK version to `3.35.0` to support `FormField.onReset` and `Brightness` from `'package:flutter/widgets.dart'`
 
 ## 0.30.0
 
@@ -886,7 +890,7 @@
 
 ## 0.10.0
 
-- __BREAKING CHANGE__: Rename `children` parameter of `ShadContextMenu` and `ShadContextMenuRegion` into `items`.
+- **BREAKING CHANGE**: Rename `children` parameter of `ShadContextMenu` and `ShadContextMenuRegion` into `items`.
 
 ## 0.9.8
 

--- a/lib/src/utils/mouse_area.dart
+++ b/lib/src/utils/mouse_area.dart
@@ -151,7 +151,7 @@ class MouseAreaSurfaceRenderBox extends RenderProxyBoxWithHitTestBehavior
 
   @override
   bool hitTest(BoxHitTestResult result, {required Offset position}) {
-    if (!size.contains(position)) {
+    if (!hasSize || !size.contains(position)) {
       return false;
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shadcn_ui
 description: shadcn/ui ported in Flutter. Awesome UI components for Flutter, fully customizable.
-version: 0.53.5
+version: 0.53.6
 homepage: https://mariuti.com/flutter-shadcn-ui
 repository: https://github.com/nank1ro/flutter-shadcn-ui
 documentation: https://mariuti.com/flutter-shadcn-ui


### PR DESCRIPTION
### Description
Fixes an issue where `MouseAreaSurfaceRenderBox` throws a `Failed assertion: 'hasSize'` when a hit test is performed before the render box has completed its first layout phase.

This occurs mostly on desktop platforms (Linux, macOS, Windows) when the mouse pointer emits an event during the initial application boot or resize, before the layout tree has settled.

By adhering to the standard `RenderBox` contract and short-circuiting the `hitTest` via `!hasSize`, this avoids the framework panic and correctly signals that the surface isn't yet ready to process pointer events.

Since this is a trivial isolated assertion safety fix, this does not have a linked issue. Fixes #none

### Changes Made
* Added a `!hasSize` guard before accessing `size` in `MouseAreaSurfaceRenderBox.hitTest()`
* Bumped version to 0.53.6
* Added changelog entry

## Testing this PR

To try this branch, add the following to your `pubspec.yaml`:

```yaml
shadcn_ui:
    git:
      url: https://github.com/turkananation/flutter-shadcn-ui
      ref: fix/mouse-area-has-size-assertion
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making.
- [x] I followed the [Data Driven Fixes] where supported.
- [x] All existing and new tests are passing.
- [x] I bumped the package version following the Semantic Versioning guidelines.
- [x] I updated the `CHANGELOG.md` file with a summary of changes made following the format already used.