### PR TITLE
fix(sheet): respect keyboard insets in showShadSheet by using opaque=…

### DIFF
--- a/lib/src/components/dialog.dart
+++ b/lib/src/components/dialog.dart
@@ -28,6 +28,7 @@ class ShadDialogRoute<T> extends PopupRoute<T> {
     this.reverseTransitionDuration = const Duration(milliseconds: 200),
     this.transitionBuilder,
     this.anchorPoint,
+    this.opaque = true,
     super.settings,
   });
 
@@ -51,6 +52,9 @@ class ShadDialogRoute<T> extends PopupRoute<T> {
   final RouteTransitionsBuilder? transitionBuilder;
 
   final Offset? anchorPoint;
+
+  @override
+  final bool opaque;
 
   @override
   Widget buildPage(
@@ -122,6 +126,12 @@ Future<T?> showShadDialog<T>({
   /// The variant of the dialog to display.
   /// Defaults to [ShadDialogVariant.primary].
   ShadDialogVariant variant = ShadDialogVariant.primary,
+
+  /// Whether the route occludes the routes behind it.
+  /// When false, [MediaQuery.viewInsetsOf] from the host scaffold will be
+  /// available in the dialog context, allowing keyboard-aware content.
+  /// Defaults to true (standard dialog behavior).
+  bool opaque = true,
 }) {
   final theme = ShadTheme.of(context);
   final effectiveDialogTheme = switch (variant) {
@@ -169,6 +179,7 @@ Future<T?> showShadDialog<T>({
       barrierLabel: barrierLabel,
       anchorPoint: anchorPoint,
       settings: routeSettings,
+      opaque: opaque,
       transitionDuration: maxCompletionDuration(effectiveAnimateIn),
       reverseTransitionDuration: maxCompletionDuration(effectiveAnimateOut),
       transitionBuilder: (context, animation, secondaryAnimation, child) {

--- a/lib/src/components/sheet.dart
+++ b/lib/src/components/sheet.dart
@@ -93,10 +93,38 @@ Future<T?> showShadSheet<T>({
 
   return showShadDialog(
     context: context,
+    opaque: false,
     builder: (context) {
-      return ShadSheetInheritedWidget(
-        side: effectiveSide,
-        child: builder(context),
+      final viewInsets = MediaQuery.of(context).viewInsets;
+      final hasInset = effectiveSide == ShadSheetSide.bottom
+          ? viewInsets.bottom > 0
+          : effectiveSide == ShadSheetSide.top
+              ? viewInsets.top > 0
+              : effectiveSide == ShadSheetSide.left
+                  ? viewInsets.left > 0
+                  : viewInsets.right > 0;
+      return AnimatedPadding(
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.linearToEaseOut,
+        padding: EdgeInsets.only(
+          bottom: effectiveSide == ShadSheetSide.bottom
+              ? viewInsets.bottom
+              : 0,
+          top: effectiveSide == ShadSheetSide.top ? viewInsets.top : 0,
+          left: effectiveSide == ShadSheetSide.left ? viewInsets.left : 0,
+          right: effectiveSide == ShadSheetSide.right ? viewInsets.right : 0,
+        ),
+        child: MediaQuery.removeViewInsets(
+          context: context,
+          removeBottom: hasInset,
+          removeTop: hasInset,
+          removeLeft: hasInset,
+          removeRight: hasInset,
+          child: ShadSheetInheritedWidget(
+            side: effectiveSide,
+            child: builder(context),
+          ),
+        ),
       );
     },
     barrierColor: barrierColor,


### PR DESCRIPTION
## Summary
- Exposes `opaque` property on `ShadDialogRoute` / `showShadDialog` so sheet routes can opt out of the default opaque overlay behaviour
- `showShadSheet` now uses `opaque: false`, wraps content in `AnimatedPadding(viewInsets)` to shift up on keyboard appearance, and `MediaQuery.removeViewInsets` to prevent double accounting inside child widgets

## Problem
When using an expandable `ShadSheet` with a `TextField` (e.g. chat input), the software keyboard would overlap or corrupt the layout. This happened because the route was opaque, causing the overlay to zero out `MediaQuery.viewInsets` — the sheet content had no awareness of the keyboard.

## Fix
Mirrors how Flutter's `ModalBottomSheetRoute` handles this: non-opaque route + `AnimatedPadding` for keyboard insets + `MediaQuery.removeViewInsets` to avoid double padding inside the sheet.