### PR TITLE
fix(input): expose enabled state in semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.56.1
+
+- **FIX**: Expose `ShadInput.enabled` in the semantics tree so assistive technologies and web tests can distinguish enabled and disabled inputs.
+
 ## 0.56.0
 
 - **BREAKING**: `slang` 4.18 renames the generated localization classes: `ShadLocalizationsDataTimePickerEn`, `ShadLocalizationsDataDatePickerEn`, `ShadLocalizationsDataInputEn` and `ShadLocalizationsDataKeyboardToolbarEn` are now `ShadLocalizationsData$timePicker$en`, `ShadLocalizationsData$datePicker$en`, `ShadLocalizationsData$input$en` and `ShadLocalizationsData$keyboardToolbar$en`.

--- a/lib/src/components/input.dart
+++ b/lib/src/components/input.dart
@@ -1137,7 +1137,7 @@ class ShadInputState extends State<ShadInput>
                   valueListenable: effectiveController,
                   builder: (context, textEditingValue, child) {
                     final Widget editableText;
-                    final rawEditableText = SizedBox(
+                    final rawEditableTextContent = SizedBox(
                       width: widget.editableTextSize?.width,
                       height: widget.editableTextSize?.height,
                       child: EditableText(
@@ -1230,6 +1230,10 @@ class ShadInputState extends State<ShadInput>
                         showCursor: widget.showCursor,
                         groupId: effectiveGroupId,
                       ),
+                    );
+                    final rawEditableText = Semantics(
+                      enabled: widget.enabled,
+                      child: rawEditableTextContent,
                     );
 
                     if (widget.onLineCountChange != null) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shadcn_ui
 description: shadcn/ui ported in Flutter. Awesome UI components for Flutter, fully customizable.
-version: 0.56.0
+version: 0.56.1
 homepage: https://mariuti.com/flutter-shadcn-ui
 repository: https://github.com/nank1ro/flutter-shadcn-ui
 documentation: https://mariuti.com/flutter-shadcn-ui

--- a/test/src/components/input_test.dart
+++ b/test/src/components/input_test.dart
@@ -10,6 +10,35 @@ void main() {
   }
 
   group('ShadInput', () {
+    testWidgets('publishes enabled state on the editable semantics node', (
+      tester,
+    ) async {
+      final semanticsHandle = tester.ensureSemantics();
+      try {
+        await tester.pumpWidget(createTestWidget(const ShadInput()));
+        final enabledData = tester
+            .getSemantics(find.byType(EditableText))
+            .getSemanticsData();
+        expect(
+          enabledData.flagsCollection.isEnabled.toBoolOrNull(),
+          isTrue,
+        );
+
+        await tester.pumpWidget(
+          createTestWidget(const ShadInput(enabled: false)),
+        );
+        final disabledData = tester
+            .getSemantics(find.byType(EditableText))
+            .getSemanticsData();
+        expect(
+          disabledData.flagsCollection.isEnabled.toBoolOrNull(),
+          isFalse,
+        );
+      } finally {
+        semanticsHandle.dispose();
+      }
+    });
+
     testWidgets('ShadInput matches goldens', (tester) async {
       await tester.pumpWidget(
         createTestWidget(


### PR DESCRIPTION
## Summary

- Publish ShadInput.enabled on the editable semantics node.
- Add a widget regression test covering both enabled and disabled inputs.
- Bump the package to 0.56.1 and document the fix.

Closes #679

## Testing

- Flutter 3.41.9: flutter analyze passes.
- Flutter 3.41.9: test/src/components/input_test.dart passes.
- dart run build_runner build completes without generated changes.
- Full Linux PR workflow passes on commit e69f9b5: import checks, build-runner cleanliness, analysis, complete test suite, and downgraded-dependency analysis ([run](https://github.com/theomarie/flutter-shadcn-ui/actions/runs/30893377983)).

## Testing this PR

To try this branch, add the following to your pubspec.yaml:

```yaml
shadcn_ui:
  git:
    url: https://github.com/theomarie/flutter-shadcn-ui
    ref: fix/input-enabled-semantics
```

## Pre-launch Checklist

- [x] I read the Contributor Guide and followed the submission process.
- [x] I read and followed the Flutter Style Guide.
- [x] I listed the issue fixed by this PR.
- [x] I updated the relevant documentation and changelog.
- [x] I added a regression test for the change.
- [x] I followed Data Driven Fixes where supported (not applicable here).
- [x] All existing and new tests pass in the Linux mirror CI.
- [x] I bumped the package version following the repository convention.
- [x] I updated CHANGELOG.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility by exposing the input’s enabled or disabled state to assistive technologies and web tests.
  * Added coverage to verify enabled-state semantics.

* **Documentation**
  * Added a changelog entry describing the accessibility fix.

* **Chores**
  * Updated the package version to 0.56.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->