### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,4 +93,4 @@ Another library could probably come first with more widgets, but in the long run
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=nank1ro/flutter-shadcn-ui&type=Date)](https://star-history.com/#nank1ro/flutter-shadcn-ui&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=nank1ro/flutter-shadcn-ui&type=Date)](https://star-history.dera.page/#nank1ro/flutter-shadcn-ui&Date)


### PR DESCRIPTION
The star history chart in the README stopped rendering because of GitHub stargazer API restrictions. This PR points the chart to a working provider so the chart is visible again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README’s Star History chart image and link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->