### PR TITLE
fix(tooltip): hide the tooltip when its route is no longer displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.56.3
+
+- **FIX**: Hide a `ShadTooltip` shown by a tap when another page or dialog opens on top of it, so it is not shown again once that page or dialog is dismissed.
+
 ## 0.56.2
 
 - **FIX**: Guard `ShadSelect`'s `animateToTop`/`animateToBottom` against a detached `ScrollController`. The scroll-to-top/bottom buttons kick off an animation on hover, but if the popover closed before or during it, reading `scrollController.offset`/`.position` threw `Bad state: No element` out of the async loop (the scroll listener already had this `hasClients` guard) (#686).

--- a/lib/src/utils/gesture_detector.dart
+++ b/lib/src/utils/gesture_detector.dart
@@ -256,6 +256,38 @@ class ShadGestureDetector extends StatefulWidget {
 class _ShadGestureDetectorState extends State<ShadGestureDetector> {
   bool hovered = false;
 
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // Reset the hover state when another route covers this widget. A hover
+    // started by a tap (see [ShadHoverStrategies]) has no pointer that can
+    // exit the widget, so without this it would survive the navigation and be
+    // restored, eg showing a tooltip again, once the route is displayed again.
+    //
+    // [ModalRoute.isCurrentOf] covers the routes pushed on the same navigator,
+    // including the non-opaque ones such as a dialog, while [TickerMode]
+    // covers the opaque routes pushed on a parent navigator, because the
+    // overlay disables the tickers of the entries it hides. Both are read
+    // unconditionally so that both dependencies are registered.
+    final isCurrent = ModalRoute.isCurrentOf(context) ?? true;
+    final tickersEnabled = TickerMode.valuesOf(context).enabled;
+    if ((isCurrent && tickersEnabled) || !hovered) return;
+    // Resolved here because [ShadTheme.of] must not be called from a
+    // post-frame callback.
+    final hoverStrategies =
+        widget.hoverStrategies ?? ShadTheme.of(context).hoverStrategies;
+    // Deferred because the listeners may rebuild widgets outside of this
+    // subtree, eg the overlay of a tooltip, which is not allowed during a
+    // build. The state is cleared inside the callback so that it never
+    // disagrees with what the listeners were told.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      hovered = false;
+      widget.onHoverChange?.call(false);
+      hoverStrategies.onHoverChange?.call(false);
+    });
+  }
+
   // See https://github.com/nank1ro/flutter-shadcn-ui/issues/319
   Offset correctGlobalPosition(BuildContext context, Offset globalPosition) {
     // Get the root navigator's overlay (screen coordinates)
@@ -569,11 +601,13 @@ class _ShadGestureDetectorState extends State<ShadGestureDetector> {
       child: MouseRegion(
         cursor: widget.cursor,
         onEnter: (_) {
+          if (hovered) return;
           hovered = true;
           widget.onHoverChange?.call(true);
           effectiveHoverStrategies.onHoverChange?.call(true);
         },
         onExit: (_) {
+          if (!hovered) return;
           hovered = false;
           widget.onHoverChange?.call(false);
           effectiveHoverStrategies.onHoverChange?.call(false);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: shadcn_ui
 description: shadcn/ui ported in Flutter. Awesome UI components for Flutter, fully customizable.
-version: 0.56.2
+version: 0.56.3
 homepage: https://mariuti.com/flutter-shadcn-ui
 repository: https://github.com/nank1ro/flutter-shadcn-ui
 documentation: https://mariuti.com/flutter-shadcn-ui

--- a/test/src/components/tooltip_test.dart
+++ b/test/src/components/tooltip_test.dart
@@ -80,6 +80,13 @@ void main() {
       // On touch devices a tap shows the tooltip, and there is no pointer to
       // exit the button and hide it again.
       await tester.tap(find.text('trigger'));
+      // Two pumps: one for the tap's onTap to toggle the tooltip open and
+      // push the route, another for the pushed route and the reopened
+      // tooltip to actually build, before anything settles and this fix
+      // hides the tooltip again.
+      await tester.pump();
+      await tester.pump();
+      expect(find.text('Tooltip'), findsOneWidget);
       await tester.pumpAndSettle();
       await popSecondPage(tester);
 
@@ -91,6 +98,13 @@ void main() {
       await pumpNavigationApp(tester, nested: true);
 
       await tester.tap(find.text('trigger'));
+      // Two pumps: one for the tap's onTap to toggle the tooltip open and
+      // push the route, another for the pushed route and the reopened
+      // tooltip to actually build, before anything settles and this fix
+      // hides the tooltip again.
+      await tester.pump();
+      await tester.pump();
+      expect(find.text('Tooltip'), findsOneWidget);
       await tester.pumpAndSettle();
       await popSecondPage(tester);
 
@@ -105,6 +119,13 @@ void main() {
       await pumpNavigationApp(tester, opaque: false);
 
       await tester.tap(find.text('trigger'));
+      // Two pumps: one for the tap's onTap to toggle the tooltip open and
+      // push the route, another for the pushed route and the reopened
+      // tooltip to actually build, before anything settles and this fix
+      // hides the tooltip again.
+      await tester.pump();
+      await tester.pump();
+      expect(find.text('Tooltip'), findsOneWidget);
       await tester.pumpAndSettle();
       await popSecondPage(tester);
 

--- a/test/src/components/tooltip_test.dart
+++ b/test/src/components/tooltip_test.dart
@@ -1,6 +1,8 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shadcn_ui/src/app.dart';
+import 'package:shadcn_ui/src/components/button.dart';
 import 'package:shadcn_ui/src/components/tooltip.dart';
 
 void main() {
@@ -27,6 +29,115 @@ void main() {
         matchesGoldenFile('goldens/tooltip.png'),
       );
       await tester.pumpAndSettle();
+    });
+
+    // Pumps a tooltip whose button pushes a second route, on the navigator
+    // above the one holding the tooltip when [nested], and a non-opaque route
+    // such as a dialog when not [opaque].
+    Future<void> pumpNavigationApp(
+      WidgetTester tester, {
+      bool nested = false,
+      bool opaque = true,
+    }) {
+      const secondPage = Scaffold(body: Text('second page'));
+      final tooltip = Builder(
+        builder: (context) => ShadTooltip(
+          builder: (context) => const Text('Tooltip'),
+          child: ShadButton(
+            onPressed: () => Navigator.of(context, rootNavigator: nested).push(
+              opaque
+                  ? MaterialPageRoute<void>(builder: (_) => secondPage)
+                  : RawDialogRoute<void>(pageBuilder: (_, _, _) => secondPage),
+            ),
+            child: const Text('trigger'),
+          ),
+        ),
+      );
+      return tester.pumpWidget(
+        createTestWidget(
+          nested
+              ? Navigator(
+                  onGenerateRoute: (_) =>
+                      MaterialPageRoute<void>(builder: (_) => tooltip),
+                )
+              : tooltip,
+        ),
+      );
+    }
+
+    // Pops the route pushed by the button of [pumpNavigationApp].
+    Future<void> popSecondPage(WidgetTester tester) async {
+      expect(find.text('second page'), findsOneWidget);
+      Navigator.of(tester.element(find.text('second page'))).pop();
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('is hidden again after a tap pushes and pops a route', (
+      tester,
+    ) async {
+      await pumpNavigationApp(tester);
+
+      // On touch devices a tap shows the tooltip, and there is no pointer to
+      // exit the button and hide it again.
+      await tester.tap(find.text('trigger'));
+      await tester.pumpAndSettle();
+      await popSecondPage(tester);
+
+      expect(find.text('Tooltip'), findsNothing);
+    });
+
+    testWidgets('is hidden again when a route of a parent navigator is pushed '
+        'and popped', (tester) async {
+      await pumpNavigationApp(tester, nested: true);
+
+      await tester.tap(find.text('trigger'));
+      await tester.pumpAndSettle();
+      await popSecondPage(tester);
+
+      expect(find.text('Tooltip'), findsNothing);
+    });
+
+    testWidgets('is hidden again after a tap opens and closes a dialog', (
+      tester,
+    ) async {
+      // A dialog is not opaque, so it does not disable the tickers of the page
+      // below it.
+      await pumpNavigationApp(tester, opaque: false);
+
+      await tester.tap(find.text('trigger'));
+      await tester.pumpAndSettle();
+      await popSecondPage(tester);
+
+      expect(find.text('Tooltip'), findsNothing);
+    });
+
+    testWidgets('is hovered again after a route push and pop with a mouse', (
+      tester,
+    ) async {
+      await pumpNavigationApp(tester);
+      final trigger = find.text('trigger');
+
+      final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await mouse.addPointer(location: Offset.zero);
+      addTearDown(mouse.removePointer);
+
+      await mouse.moveTo(tester.getCenter(trigger));
+      await tester.pumpAndSettle();
+      expect(find.text('Tooltip'), findsOneWidget);
+
+      await tester.tap(trigger, kind: PointerDeviceKind.mouse);
+      await tester.pumpAndSettle();
+
+      // The pointer is moved away while the second page is visible.
+      await mouse.moveTo(const Offset(700, 500));
+      await tester.pumpAndSettle();
+      await popSecondPage(tester);
+      expect(find.text('Tooltip'), findsNothing);
+
+      // The hover state was reset, so hovering the button shows it again.
+      await mouse.moveTo(tester.getCenter(trigger));
+      await tester.pumpAndSettle();
+      expect(find.text('Tooltip'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Symptom

A `ShadTooltip` shown by a **tap** stays open behind a page or dialog opened on top of it,
and is still displayed once that page or dialog is dismissed.

Tapping is how tooltips are shown on touch devices: the default `ShadHoverStrategies` put
`onTap` in both `hover` and `unhover`, so a tap toggles the hover state. Unlike a mouse
hover there is no pointer that can later leave the child, so nothing ever hides the tooltip
again.

## Root cause

`_ShadGestureDetectorState.hovered` is only cleared by `MouseRegion.onExit`. When the hover
was started by a tap there is no pointer to exit, so `hovered` survives the navigation —
and with it the tooltip that is driven by `onHoverChange`.

## The fix

One `didChangeDependencies` in `ShadGestureDetector`, no new files, nothing on the tooltip
side:

```dart
final isCurrent = ModalRoute.isCurrentOf(context) ?? true;
final tickersEnabled = TickerMode.valuesOf(context).enabled;
if ((isCurrent && tickersEnabled) || !hovered) return;
```

Two inherited signals, both read unconditionally so both dependencies are always registered
and neither transition can be missed:

- **`ModalRoute.isCurrentOf`** covers everything pushed on the same navigator, including
  the non-opaque routes — `showShadDialog`, `showShadSheet`, `showModalBottomSheet` — which
  never make the page below them invisible to the overlay.
- **`TickerMode`** covers opaque routes pushed on a *parent* navigator. `Overlay` builds
  every entry below an opaque entry with `tickerEnabled: false`
  (`_OverlayEntryWidget` wraps its child in a `TickerMode`), and that disabled `TickerMode`
  is inherited by the whole subtree — including a child `Navigator` nested inside the
  covered entry, which `isCurrentOf` alone would still report as current.

When the guard passes, the hover state is reset and `onHoverChange(false)` is delivered. The
notification is deferred with `addPostFrameCallback` because the listeners can rebuild
widgets outside this subtree (the tooltip's overlay), which is not allowed during a build;
the state is cleared inside that callback so it never disagrees with what listeners were
told. The `MouseRegion.onEnter`/`onExit` early returns keep the notification from being sent
twice when the pointer also leaves.

`ShadDialogRoute` is the only route pushed anywhere in `lib/`. Tooltip, popover, select,
context menu, menubar and the pickers are all `ShadPortal`/`OverlayPortal`-based and push no
route, so opening one of them does not affect `isCurrent` and cannot strand hover elsewhere.

### Known limits

- A tooltip opened programmatically through `ShadTooltipController` leaves `hovered == false`
  and is not affected by this; only the hover-driven path is reset.
- A non-default `ShadTooltip.reverseDuration` postpones the hide until the tickers come back,
  because a muted `Ticker` never completes the reverse animation. The default theme uses
  `Duration.zero`, so this does not bite today.

## Tests

`test/src/components/tooltip_test.dart`:

1. **tap pushes and pops a route** — the tooltip is not visible after the pop. Fails on `main`.
2. **a route of a parent navigator is pushed and popped** — same, with the tooltip inside a
   nested `Navigator` and the push on the root one. Fails on `main`.
3. **tap opens and closes a dialog** — a non-opaque `PopupRoute`. Fails on `main`, and also
   fails if the `ModalRoute.isCurrentOf` term is removed, while tests 1 and 2 keep passing —
   so each half of the guard is pinned by a test.
4. **route push and pop with a mouse** — regression guard: the pointer moves away while the
   second page is up, and after the pop hovering the trigger shows the tooltip again. This
   one also passes on `main`; it is there to prove the reset does not strand the mouse path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed tooltips that remained visible after navigation and reappeared when returning to a screen.
  - Hover states now reset when widgets are hidden or covered by another route.
  - Prevented redundant hover state changes during pointer interactions.

- **Tests**
  - Added coverage for tooltip behavior across route pushes, dialogs, and mouse interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->